### PR TITLE
remove operatorgroup length check

### DIFF
--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -127,9 +127,7 @@ func (r *AccountIAMReconciler) verifyPrereq(ctx context.Context, instance *opera
 	if err != nil {
 		return err
 	}
-	if len(og.Items) != 1 {
-		return errors.New("there should be exactly one OperatorGroup in this namespace")
-	}
+
 	providedApis := og.Items[0].Annotations["olm.providedAPIs"]
 
 	if !strings.Contains(providedApis, "postgresql") {

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -23,7 +23,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"os"
-	"strings"
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
@@ -126,12 +125,6 @@ func (r *AccountIAMReconciler) verifyPrereq(ctx context.Context, instance *opera
 	})
 	if err != nil {
 		return err
-	}
-
-	providedApis := og.Items[0].Annotations["olm.providedAPIs"]
-
-	if !strings.Contains(providedApis, "postgresql") {
-		return errors.New("missing EDB prereq")
 	}
 
 	dbPass, err := generatePassword()

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -89,10 +89,7 @@ var BootstrapData BootstrapSecret
 // move the current state of the cluster closer to the desired state.
 // TODO(user): Modify the Reconcile function to compare the state specified by
 // the AccountIAM object against the actual cluster state, and then
-// perform operations to make the cluster state 
-
-
-the state specified by
+// perform operations to make the cluster state reflect the state specified by
 // the user.
 //
 // For more details, check Reconcile and its Result here:

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -134,10 +134,6 @@ func (r *AccountIAMReconciler) verifyPrereq(ctx context.Context, instance *opera
 		return errors.New("missing EDB prereq")
 	}
 
-	if !strings.Contains(providedApis, "WebSphereLibertyApplication") {
-		return errors.New("missing Websphere Liberty prereq")
-	}
-
 	dbPass, err := generatePassword()
 	if err != nil {
 		return err


### PR DESCRIPTION
remove operatorgroup length check, it might cause error when operator is installed in allnamespace mode