### PR TITLE
UI installation with on-prem Redis

### DIFF
--- a/bundle/manifests/ibm-user-management-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-user-management-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     categories: Security
     certified: "false"
     containerImage: icr.io/cpopen/ibm-user-management-operator:latest
-    createdAt: "2024-07-29T18:37:34Z"
+    createdAt: "2024-07-31T20:52:03Z"
     description: Operator for managing deployment of account-iam service.
     olm.skipRange: <0.0.0
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
@@ -246,6 +246,18 @@ spec:
           resources:
           - rolebindings
           - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - redis.ibm.com
+          resources:
+          - rediscps
           verbs:
           - create
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -206,6 +206,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - redis.ibm.com
+  resources:
+  - rediscps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -233,7 +233,7 @@ func (r *AccountIAMReconciler) verifyPrereq(ctx context.Context, instance *opera
 
 	// Generate PG password
 	klog.Info("Generating PG password...")
-	pgPassword, err := generatePassword()
+	pgPassword, err := generatePassword(20)
 
 	if err != nil {
 		return err
@@ -775,6 +775,12 @@ func (r *AccountIAMReconciler) initUIBootstrapData(ctx context.Context, instance
 		klog.Infof("redisCert: %s", redisCert)
 	}
 
+	SessionSecret, err := generatePassword(48)
+	if err != nil {
+		return err
+	}
+	klog.Info("SessionSecret: ", string(SessionSecret))
+
 	decodedClientID, err := base64.StdEncoding.DecodeString(BootstrapData.ClientID)
 	if err != nil {
 		return err
@@ -792,7 +798,7 @@ func (r *AccountIAMReconciler) initUIBootstrapData(ctx context.Context, instance
 		IAMGlobalAPIKey:            string(apiKey),
 		RedisHost:                  redisURlssl,
 		RedisCA:                    redisCert,
-		SessionSecret:              "placeholder value because we do not know what this is for yet",
+		SessionSecret:              string(SessionSecret),
 		DeploymentCloud:            "IBM_CLOUD",
 		IAMAPI:                     concat("https://account-iam-", instance.Namespace, ".apps.", domain),
 		NodeEnv:                    "production",

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -37,8 +37,8 @@ func NewUnstructured(group, kind, version string) *unstructured.Unstructured {
 	return u
 }
 
-func generatePassword() ([]byte, error) {
-	random := make([]byte, 20)
+func generatePassword(len int) ([]byte, error) {
+	random := make([]byte, len)
 	_, err := rand.Read(random)
 	if err != nil {
 		return nil, err

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -95,7 +95,6 @@ func insertColonInURL(redisURL string) string {
 // waitForOperatorReady check operator status in OperandRequest
 func waitForOperatorReady(ctx context.Context, k8sClient client.Client, opreqName, ns string) error {
 	return wait.PollImmediate(30*time.Second, 10*time.Minute, func() (bool, error) {
-		klog.Info("Start to check operator status in OperandRequest")
 		operandRequest := &odlm.OperandRequest{}
 		if err := k8sClient.Get(ctx, client.ObjectKey{Name: opreqName, Namespace: ns}, operandRequest); err != nil {
 			if k8serrors.IsNotFound(err) {
@@ -119,7 +118,7 @@ func waitForOperatorReady(ctx context.Context, k8sClient client.Client, opreqNam
 
 // waitForOperandReady checks if all services in OperandRequest are ready
 func waitForOperandReady(ctx context.Context, k8sClient client.Client, opreqName, ns string) error {
-	return wait.PollImmediate(30*time.Second, 10*time.Minute, func() (bool, error) {
+	return wait.PollImmediate(60*time.Second, 10*time.Minute, func() (bool, error) {
 		operandRequest := &odlm.OperandRequest{}
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: opreqName, Namespace: ns}, operandRequest); err != nil {
 			return false, err
@@ -138,7 +137,6 @@ func waitForOperandReady(ctx context.Context, k8sClient client.Client, opreqName
 			return true, nil
 		}
 
-		klog.Infof("Not all services in OperandRequest %s in namespace %s are Ready yet...", opreqName, ns)
 		return false, nil
 	})
 }

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -1,13 +1,51 @@
 package controller
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"os"
 	"strings"
+	"time"
+
+	"github.com/IBM/ibm-user-management-operator/internal/resources"
+	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
 	ImageList = []string{"MCSP_UTILS_IMAGE", "ACCOUNT_IAM_APP_IMAGE", "MCSP_IM_CONFIG_JOB_IMAGE", "ACCOUNT_IAM_UI_INSTANCE_SERVICE_IMAGE", "ACCOUNT_IAM_UI_API_SERVICE_IMAGE"}
 )
+
+// NewUnstructured return Unstructured object
+func NewUnstructured(group, kind, version string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   group,
+		Kind:    kind,
+		Version: version})
+	return u
+}
+
+func generatePassword() ([]byte, error) {
+	random := make([]byte, 20)
+	_, err := rand.Read(random)
+	if err != nil {
+		return nil, err
+	}
+	encoded := base64.StdEncoding.EncodeToString(random)
+	encoded2 := base64.StdEncoding.EncodeToString([]byte(encoded))
+	result := []byte(encoded2)
+	return result, nil
+}
 
 func concat(s ...string) string {
 	return strings.Join(s, "")
@@ -24,4 +62,142 @@ func replaceImages(resource string) (result string) {
 func getImage(imageName string) string {
 	image, _ := os.LookupEnv(imageName)
 	return image
+}
+
+// waitForOperatorReady check operator status in OperandRequest
+func waitForOperatorReady(ctx context.Context, k8sClient client.Client, opreqName, ns string) error {
+	return wait.PollImmediate(30*time.Second, 10*time.Minute, func() (bool, error) {
+		operandRequest := &odlm.OperandRequest{}
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: opreqName, Namespace: ns}, operandRequest); err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.V(2).Infof("OperandRequest %s not found in namespace %s", opreqName, ns)
+				return false, nil
+			}
+			klog.ErrorS(err, "Failed to get OperandRequest", "OperandRequest", opreqName)
+			return false, err
+		}
+
+		klog.Infof("Waiting for all operators to be %s...", resources.OpreqPhaseRunning)
+
+		if operandRequest.Status.Phase == resources.OpreqPhaseRunning {
+			klog.Infof("All operators are running in namespace %s.", ns)
+			return true, nil
+		}
+
+		return false, nil
+	})
+}
+
+// waitForOperandReady checks if all services in OperandRequest are ready
+func waitForOperandReady(ctx context.Context, k8sClient client.Client, opreqName, ns string) error {
+	return wait.PollImmediate(30*time.Second, 10*time.Minute, func() (bool, error) {
+		operandRequest := &odlm.OperandRequest{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: opreqName, Namespace: ns}, operandRequest); err != nil {
+			return false, err
+		}
+
+		allReady := true
+		for _, service := range operandRequest.Status.Services {
+			if service.Status != resources.OperandStatusReady {
+				klog.Infof("Service %s in namespace %s is not Ready. Current status: %s", service.OperatorName, service.Namespace, service.Status)
+				allReady = false
+			}
+		}
+
+		if allReady {
+			klog.Infof("All services in OperandRequest %s in namespace %s are Ready", opreqName, ns)
+			return true, nil
+		}
+
+		klog.Infof("Not all services in OperandRequest %s in namespace %s are Ready yet...", opreqName, ns)
+		return false, nil
+	})
+}
+
+// waitForResource waits for the resource to be completed
+func waitForRediscp(ctx context.Context, k8sClient client.Client, ns, name, group, kind, version, compStatus string) error {
+	return wait.PollImmediate(30*time.Second, 10*time.Minute, func() (bool, error) {
+
+		redisCR := NewUnstructured(group, kind, version)
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, redisCR); err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.V(2).Infof("Redis CR %s not found in namespace %s", name, ns)
+				return false, nil
+			}
+			klog.ErrorS(err, "Failed to get Redis CR", "Redis CR", name)
+			return false, err
+		}
+
+		// need to check if redisCR.Status.RedisStatus is completed
+		if redisCR.Object != nil {
+			if redisCR.Object["status"] != nil {
+				if redisCR.Object["status"].(map[string]interface{})["redisStatus"] == compStatus {
+					klog.Infof("Rediscp CR %s in namespace %s is completed", name, ns)
+					return true, nil
+				}
+			}
+		}
+
+		klog.Infof("Redis CR %s in namespace %s is not completed yet...", name, ns)
+		return false, nil
+	})
+}
+
+// waitForDeploymentReady waits for the deployment to be ready
+func waitForDeploymentReady(ctx context.Context, k8sClient client.Client, ns, label string) error {
+
+	return wait.PollImmediate(20*time.Second, 10*time.Minute, func() (bool, error) {
+		deployments := &appsv1.DeploymentList{}
+
+		if err := k8sClient.List(ctx, deployments, &client.ListOptions{Namespace: ns}); err != nil {
+			klog.V(2).ErrorS(err, "Failed to get deployment", "deployment", label)
+			return false, nil
+		}
+
+		var matchedDeployment *appsv1.Deployment
+		for _, deployment := range deployments.Items {
+			if strings.HasPrefix(deployment.Name, label) {
+				matchedDeployment = &deployment
+				break
+			}
+		}
+
+		if matchedDeployment == nil {
+			klog.Infof("No deployment found with prefix %s in namespace %s", label, ns)
+			return false, nil
+		}
+
+		klog.Infof("Waiting for Deployment %s to be ready...", label)
+
+		desiredReplicas := *matchedDeployment.Spec.Replicas
+		readyReplicas := matchedDeployment.Status.ReadyReplicas
+
+		if readyReplicas == desiredReplicas {
+			klog.Infof("Deployment %s is ready with %d/%d replicas.", label, readyReplicas, desiredReplicas)
+			return true, nil
+		}
+
+		return false, nil
+	})
+}
+
+// waitForJob waits for the job to be succeeded
+func waitForJob(ctx context.Context, k8sClient client.Client, ns, name string) error {
+
+	return wait.PollImmediate(20*time.Second, 2*time.Minute, func() (bool, error) {
+		job := &batchv1.Job{}
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: ns}, job); err != nil {
+			klog.V(2).ErrorS(err, "Failed to get job", "job", name)
+			return false, err
+		}
+
+		klog.Infof("Waiting for Job %s to be ready...", name)
+
+		if job.Status.Succeeded > 0 {
+			klog.Infof("Job %s is succeeded.", name)
+			return true, nil
+		}
+
+		return false, nil
+	})
 }

--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -39,6 +39,12 @@ const (
 	RedisAPIGroup = "redis.ibm.com"
 	// RedisVersion is the version of Redis
 	RedisVersion = "v1"
+	//RedisURLssl
+	RedisURLssl = "redis-url-ssl"
+	// RedisURL is the Certificate of Redis
+	RedisCert = "account-iam-ui-redis-cert"
+	// RedisCertKey is the key of Redis CA Certificate
+	RedisCertKey = "cacertb64.pem"
 	// OpreqPhaseRunning is the Running status of Operand
 	OpreqPhaseRunning = "Running"
 	// OperandStatusReady is the Ready status of Operand
@@ -53,4 +59,8 @@ const (
 	EDBAPIGroupVersion = "postgresql.k8s.enterprisedb.io/v1"
 	// IMConfigJob is the name of the IM configuration job
 	IMConfigJob = "mcsp-im-config-job"
+	// IMAPISecret is the secret where the IM API key is stored
+	IMAPISecret = "mcsp-im-integration-api-key"
+	// IMAPIKey is the key in the secret.data where the IM API key is stored
+	IMAPIKey = "API_KEY"
 )

--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -20,23 +20,37 @@ const (
 	// Default User Management CR
 	UserMgmtCR = "AccountIAM"
 	// Default OperandRequest
-	UserMgmtOpreq = "user-management-request"
+	UserMgmtOpreq = "ibm-user-management-request"
 	// OpreqKind is the kind of OperandConfig
 	OpreqKind = "OperandRequest"
-	// OperandStatusRedy is the Ready status of Operand
-	OperandStatusRedy = "Ready"
 	// WebSphere is the name of WebSphere Operator
 	WebSpherePackage = "ibm-websphere-liberty"
 	// WebSphereAPIGroupVersion is the api group version of WebSphereLibertyApplication
 	WebSphereAPIGroupVersion = "liberty.websphere.ibm.com/v1"
 	// WebSphereKind is the kind of WebSphereLibertyApplication
 	WebSphereKind = "WebSphereLibertyApplication"
+	// RedisOperator is the subscription name of Redis Operator
+	RedisOperator = "ibm-redis-cp-operator"
+	// Rediscp is the name of Redis CR
+	Rediscp = "account-iam-ui-redis"
+	// RedisKind is the kind of Redis
+	RedisKind = "Rediscp"
+	// RedisAPIGroup is the api group of Redis
+	RedisAPIGroup = "redis.ibm.com"
+	// RedisVersion is the version of Redis
+	RedisVersion = "v1"
+	// OpreqPhaseRunning is the Running status of Operand
+	OpreqPhaseRunning = "Running"
+	// OperandStatusReady is the Ready status of Operand
+	OperandStatusReady = "Ready"
+	// OperandStatusComp is the Completed status of Operand
+	OperandStatusComp = "Completed"
 	// IMPackage is the name of IM Operator
 	IMPackage = "ibm-im-operator"
-	// EDBAPIGroupVersion is the api group version of Cluster
-	EDBAPIGroupVersion = "postgresql.k8s.enterprisedb.io/v1"
 	// EDBClusterKind is the kind of Cluster
 	EDBClusterKind = "Cluster"
+	// EDBAPIGroupVersion is the api group version of Cluster
+	EDBAPIGroupVersion = "postgresql.k8s.enterprisedb.io/v1"
 	// IMConfigJob is the name of the IM configuration job
 	IMConfigJob = "mcsp-im-config-job"
 )

--- a/internal/resources/yamls/create_redis.go
+++ b/internal/resources/yamls/create_redis.go
@@ -1,0 +1,16 @@
+package yamls
+
+const RedisCRTemplate = `
+apiVersion: redis.ibm.com/v1
+kind: Rediscp
+metadata:
+  name: account-iam-ui-redis
+spec:
+  size: {{.RedisCRSize}}
+  license:
+     accept: true
+  cert_name: account-iam-ui-redis-cert
+  shutdown: false
+  scale_config: medium
+  version: {{.RedisCRVersion}}
+`


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64340

### Implement the following content:
- The user-mgmt operator created an OperandRequest requesting `ibm-redis-cp`, `ibm-websphere-liberty` and `ibm-im-operator`.
- Checked if all the requested operators are in `Running` phase.
- If the Redis CRD exists and then create a Redis CR by applying CR yaml
- If all the Operands are in `Ready` status in `ibm-user-management-request` OperandRequest
- Checked the readiness of the Redis instance.
- The operator retrieves the Redis connections info from secret