### PR TITLE
Add account iam console url

### DIFF
--- a/bundle/manifests/ibm-user-management-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-user-management-operator.clusterserviceversion.yaml
@@ -24,7 +24,7 @@ metadata:
     categories: Security
     certified: "false"
     containerImage: icr.io/cpopen/ibm-user-management-operator:latest
-    createdAt: "2024-07-31T20:52:03Z"
+    createdAt: "2024-08-07T12:21:51Z"
     description: Operator for managing deployment of account-iam service.
     nss.operator.ibm.com/managed-operators: ibm-user-management-operator
     olm.skipRange: <0.0.0
@@ -341,9 +341,9 @@ spec:
                 - name: MCSP_IM_CONFIG_JOB_IMAGE
                   value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom/mcsp-im-config-job:latest
                 - name: ACCOUNT_IAM_UI_API_SERVICE_IMAGE
-                  value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/sgrube/api_service:cs
+                  value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom/api_service:1.0.0
                 - name: ACCOUNT_IAM_UI_INSTANCE_SERVICE_IMAGE
-                  value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/sgrube/instance_service:cs
+                  value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom/instance_management_service:1.0.0
                 image: icr.io/cpopen/ibm-user-management-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -87,9 +87,9 @@ spec:
         - name: MCSP_IM_CONFIG_JOB_IMAGE
           value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom/mcsp-im-config-job:latest
         - name: ACCOUNT_IAM_UI_API_SERVICE_IMAGE
-          value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/sgrube/api_service:cs
+          value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom/api_service:1.0.0
         - name: ACCOUNT_IAM_UI_INSTANCE_SERVICE_IMAGE
-          value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/sgrube/instance_service:cs
+          value: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom/instance_management_service:1.0.0
         args:
         - --leader-elect
         image: controller:latest

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -75,8 +75,9 @@ type BootstrapSecret struct {
 	GlobalAccountIDP    string
 	GlobalAccountAud    string
 	UserValidationAPIV2 string
-	IAMHOSTURL          string
+	IAMHostURL          string
 	AccountIAMURL       string
+	AccountIAMHostURL   string
 	AccountIAMNamespace string
 }
 
@@ -411,6 +412,7 @@ func (r *AccountIAMReconciler) initBootstrapData(ctx context.Context, ns string,
 			return nil, err
 		}
 
+		accountIAMHost := strings.Replace(host, "cp-console", "account-iam-console", 1)
 		klog.Info("Creating bootstrap secret with PG password")
 		newsecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -432,7 +434,8 @@ func (r *AccountIAMReconciler) initBootstrapData(ctx context.Context, ns string,
 				"GlobalAccountAud":    []byte("mcsp-id"),
 				"AccountIAMNamespace": []byte(ns),
 				"PGPassword":          pg,
-				"IAMHOSTURL":          []byte("https://" + host),
+				"IAMHostURL":          []byte("https://" + host),
+				"AccountIAMHostURL":   []byte("https://" + accountIAMHost),
 			},
 			Type: corev1.SecretTypeOpaque,
 		}

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -799,10 +799,9 @@ func (r *AccountIAMReconciler) initUIBootstrapData(ctx context.Context, instance
 	if err != nil {
 		klog.Errorf("Failed to get secret %s in namespace %s: %v", resources.Rediscp, instance.Namespace, err)
 		return err
-	} else {
-		redisURlssl := insertColonInURL(redisURlssl)
-		klog.Infof("redisURlssl: %s", redisURlssl)
 	}
+	redisURlssl = insertColonInURL(redisURlssl)
+	klog.Infof("redisURlssl: %s", redisURlssl)
 
 	// get Redis cert
 	redisCert, err := getSecretData(ctx, r.Client, resources.RedisCert, instance.Namespace, resources.RedisCertKey)
@@ -829,8 +828,8 @@ func (r *AccountIAMReconciler) initUIBootstrapData(ctx context.Context, instance
 	}
 
 	UIBootstrapData = UIBootstrapTemplate{
-		Hostname:                   concat("account-iam-ui-inst-", instance.Namespace, ".apps.", domain),
-		InstanceManagementHostname: concat("account-iam-ui-inst-", instance.Namespace, ".apps.", domain),
+		Hostname:                   concat("account-iam-console-", instance.Namespace, ".apps.", domain),
+		InstanceManagementHostname: concat("account-iam-console-", instance.Namespace, ".apps.", domain),
 		ClientID:                   string(decodedClientID),
 		ClientSecret:               string(decodedClientSecret),
 		IAMGlobalAPIKey:            string(apiKey),

--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -60,7 +60,7 @@ const (
 	// IMConfigJob is the name of the IM configuration job
 	IMConfigJob = "mcsp-im-config-job"
 	// IMAPISecret is the secret where the IM API key is stored
-	IMAPISecret = "mcsp-im-integration-api-key"
+	IMAPISecret = "mcsp-im-integration-details"
 	// IMAPIKey is the key in the secret.data where the IM API key is stored
 	IMAPIKey = "API_KEY"
 )

--- a/internal/resources/yamls/im_config.go
+++ b/internal/resources/yamls/im_config.go
@@ -38,10 +38,12 @@ spec:
             value: debug
           - name: NAMESPACE
             value: {{ .AccountIAMNamespace }}
-          - name: IM_HOST_URL
-            value: {{ .IAMHOSTURL }}
-          - name: ACCOUNT_IAM_URL
+          - name: IM_HOST_BASE_URL
+            value: {{ .IAMHostURL }}
+          - name: ACCOUNT_IAM_BASE_URL
             value: {{ .AccountIAMURL }}
+          - name: ACCOUNT_IAM_CONSOLE_BASE_URL
+            value: {{ .AccountIAMHostURL }}
       serviceAccountName: mcsp-im-config-sa
       restartPolicy: OnFailure
 `


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/64264
Three URLs added into bootstrap:
1. CP host URL
2. Account IAM base URL (Swagger UI)
3. Account IAM console URL