### PR TITLE
add securityContext .seccompProfile field

### DIFF
--- a/bundle/manifests/ibm-user-management-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-user-management-operator.clusterserviceversion.yaml
@@ -384,11 +384,15 @@ spec:
                     cpu: 10m
                     memory: 64Mi
                 securityContext:
+                  seccompProfile:
+                    type: RuntimeDefault
                   allowPrivilegeEscalation: false
                   capabilities:
                     drop:
                     - ALL
               securityContext:
+                seccompProfile:
+                  type: RuntimeDefault
                 runAsNonRoot: true
               serviceAccountName: ibm-user-management-operator-controller-manager
               terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,8 +63,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -96,6 +96,8 @@ spec:
         imagePullPolicy: Always
         name: manager
         securityContext:
+          seccompProfile:
+            type: RuntimeDefault
           allowPrivilegeEscalation: false
           capabilities:
             drop:


### PR DESCRIPTION
**What this PR does / why we need it**:
add securityContext .ceccompProfile field to pod container
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64465