### PR TITLE
Operator vcs-ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 FROM docker.io/golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
-ARG VCS_REF
-ARG VCS_URL
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -31,6 +29,9 @@ FROM docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-edge-docker-l
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
+
+ARG VCS_REF
+ARG VCS_URL
 
 LABEL org.label-schema.vendor="IBM" \
   org.label-schema.name="ibm user management operator" \

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build -t ${IMG} \
+	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
add vcs-ref label to ibm-user-management-operator image

```
root@axe1:~/projects/go/src/ibm-user-management-operator# docker image inspect --format='{{json .Config}}' docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/ibm-user-management-operator:latest | grep vcs
{"Hostname":"","Domainname":"","User":"65532:65532","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","container=oci"],"Cmd":null,"Image":"","Volumes":null,"WorkingDir":"/","Entrypoint":["/manager"],"OnBuild":null,"Labels":{"architecture":"x86_64","build-date":"2024-07-18T15:52:43","com.redhat.component":"ubi9-minimal-container","com.redhat.license_terms":"https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI","description":"The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.","distribution-scope":"public","io.buildah.version":"1.29.0","io.k8s.description":"The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.","io.k8s.display-name":"Red Hat Universal Base Image 9 Minimal","io.openshift.expose-services":"","io.openshift.tags":"minimal rhel9","maintainer":"Red Hat, Inc.","name":"ubi9-minimal",
"org.label-schema.name":"ibm user management operator","org.label-schema.vcs-ref":"6c64537a4b84349e414349010dfa0f131e796c94","org.label-schema.vcs-url":"https://github.com/IBM/ibm-user-management-operator","org.label-schema.vendor":"IBM","release":"1194","summary":"Provides the latest release of the minimal Red Hat Universal Base Image 9.","url":"https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9-minimal/images/9.4-1194","vcs-ref":"94baa7760359088a42ad33dc22d329a5ee2c7209","vcs-type":"git","vendor":"Red Hat, Inc.","version":"9.4"}}
```