### PR TITLE
Add new data into mcsp env configmap

### DIFF
--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -498,16 +498,6 @@ func (r *AccountIAMReconciler) reconcileOperandResources(ctx context.Context, in
 		return err
 	}
 
-	klog.Infof("Creating MCSP ConfigMaps")
-	decodedData, err := r.decodeData(BootstrapData)
-	if err != nil {
-		return err
-	}
-
-	if err := r.injectData(ctx, instance, res.APP_CONFIGS, decodedData); err != nil {
-		return err
-	}
-
 	// static manifests which do not change
 	klog.Infof("Creating MCSP static yamls")
 	staticYamls := append(res.APP_STATIC_YAMLS, res.CertRotationYamls...)
@@ -535,6 +525,11 @@ func (r *AccountIAMReconciler) reconcileOperandResources(ctx context.Context, in
 		return err
 	}
 	currentIssuer := idpconfig.Data["OIDC_ISSUER_URL"]
+
+	decodedData, err := r.decodeData(BootstrapData)
+	if err != nil {
+		return err
+	}
 	idpValue := decodedData.DefaultIDPValue
 
 	if currentIssuer == idpValue {

--- a/internal/resources/yamls/app.go
+++ b/internal/resources/yamls/app.go
@@ -7,10 +7,6 @@ var APP_SECRETS = []string{
 	MpConfig,
 }
 
-var APP_CONFIGS = []string{
-	CONFIG_JWT,
-}
-
 var APP_STATIC_YAMLS = []string{
 	INGRESS,
 	EGRESS,
@@ -186,24 +182,10 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 data:
+  CLOUD_INSTANCE_ID: dev
+  CLOUD_REGION: dev
   NOTIFICATION_SERVICE_ENABLED: ""
   LOCAL_TOKEN_ISSUER: https://127.0.0.1:9443/oidc/endpoint/OP
-`
-
-const CONFIG_JWT = `
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: account-iam
-  labels:
-    by-squad: mcsp-user-management
-    for-product: all
-    bcdr-candidate: t
-    component-name: iam-services
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
-data:
-  jwt.suffix.issuer: {{ .DefaultIDPValue }}
 `
 
 const DB_MIGRATION_MCSPID = `


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/64554

To pick up new MCSP image: `icr.io/automation-saas-platform/access-management/account-iam:20240819135403-development-3f8f7784573adb1cc350ff25fdfc14c9b7a640f1`

Changes we made:

- Add two `CLOUD_INSTANCE_ID`, CLOUD_REGION` variables into data section in `account-iam-env-configmap-dev` (any values could be used here, `dev` is a random value we gave it)
- Remove `accoumt-iam` configMap as it is no longer used