### PR TITLE
Remove unnecessary data entry in bootstrap secret

### DIFF
--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -61,6 +61,8 @@ const (
 	IMConfigJob = "mcsp-im-config-job"
 	// IMOIDCCrendential is the secret where the IM OIDC credential is stored
 	IMOIDCCrendential = "ibm-iam-bindinfo-platform-oidc-credentials"
+	// IMPlatformCM is the configmap where the auth idp related information is stored
+	IMPlatformCM = "platform-auth-idp"
 	// WLPClientID is the key in the secret.data where the WLP client ID is stored
 	WLPClientID = "WLP_CLIENT_ID"
 	// IMAPISecret is the secret where the IM API key is stored

--- a/internal/resources/yamls/app.go
+++ b/internal/resources/yamls/app.go
@@ -32,6 +32,7 @@ data:
   realm: {{ .Realm }}
   client_id: {{ .ClientID }}
   client_secret: {{ .ClientSecret }}
+stringData:
   discovery_endpoint: {{ .DiscoveryEndpoint }}
 type: Opaque
 `
@@ -72,10 +73,10 @@ stringData:
   pg_db_user: user_accountiam
   pg_jdbc_password_jndi: "jdbc/iamdatasource"
   pg_ssl_mode: prefer
+  GLOBAL_ACCOUNT_IDP: {{ .GlobalAccountIDP }}
 data:
   pgPassword: {{ .PGPassword }}
   GLOBAL_ACCOUNT_AUD: {{ .GlobalAccountAud }}
-  GLOBAL_ACCOUNT_IDP: {{ .GlobalAccountIDP }}
   GLOBAL_ACCOUNT_REALM: {{ .GlobalRealmValue }}
 type: Opaque
 `
@@ -94,9 +95,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
 data:
   DEFAULT_AUD_VALUE: {{ .DefaultAUDValue }}
-  DEFAULT_IDP_VALUE: {{ .DefaultIDPValue }}
   DEFAULT_REALM_VALUE: {{ .DefaultRealmValue }}
   SRE_MCSP_GROUPS_TOKEN: {{ .SREMCSPGroupsToken }}
+stringData:
+  DEFAULT_IDP_VALUE: {{ .DefaultIDPValue }}
 type: Opaque
 `
 

--- a/internal/resources/yamls/im_config.go
+++ b/internal/resources/yamls/im_config.go
@@ -36,7 +36,7 @@ spec:
           - name: NAMESPACE
             value: {{ .AccountIAMNamespace }}
           - name: IM_HOST_BASE_URL
-            value: {{ .IAMHostURL }}
+            value: {{ .IMURL }}
           - name: ACCOUNT_IAM_BASE_URL
             value: {{ .AccountIAMURL }}
           - name: ACCOUNT_IAM_CONSOLE_BASE_URL


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/64681

- Removed the values that contain special host names and namespaces from the `user-mgmt-bootstrap` secret to unblock the Backup and Restore process.
- Created a new data structure to store the above values and pass them into the resource templates.
