### PR TITLE
Implement resource hash comparison logic in reconciliation

### DIFF
--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -19,7 +19,9 @@ package utils
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"reflect"
@@ -165,6 +167,12 @@ func GetSecretData(ctx context.Context, k8sClient client.Client, secretName, ns,
 	}
 
 	return string(data), nil
+}
+
+// HashResource generates a hash from the raw resource data
+func HashResource(rawData []byte) string {
+	hashedData := sha256.Sum256(rawData)
+	return hex.EncodeToString(hashedData[:7])
 }
 
 func CombineData(dataStructs ...interface{}) map[string]interface{} {

--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -71,4 +71,6 @@ const (
 	IMAPIKey = "API_KEY"
 	// SkipAnnotations is the annotation to skip the update of the operand resrouces
 	SkipAnnotation = "operator.ibm.com/ibm-user-management-operator.skip-update"
+	//HashedData is the key for checking the checksum of data section
+	HashedData string = "operator.ibm.com/ibm-user-management-operator.hashedData"
 )

--- a/internal/resources/yamls/account_iam.go
+++ b/internal/resources/yamls/account_iam.go
@@ -38,8 +38,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: account-iam-svc-tls-cm
-  annotations:
-    argocd.argoproj.io/sync-wave: '3'
 spec:
   commonName: account-iam.mcsp1.svc
   dnsNames:
@@ -70,8 +68,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: account-iam
-  annotations:
-    argocd.argoproj.io/sync-wave: "3"
   labels:
     app.kubernetes.io/component: backend
     app.kubernetes.io/instance: account-iam
@@ -89,7 +85,6 @@ kind: Service
 metadata:
   name: account-iam
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
     service.kubernetes.io/topology-aware-hints: Auto
     service.kubernetes.io/topology-mode: Auto
   labels:
@@ -293,7 +288,6 @@ kind: Route
 metadata:
   name: account-iam
   annotations:
-    argocd.argoproj.io/sync-wave: "3"
     openshift.io/host.generated: "true"
   labels:
     app.kubernetes.io/component: backend

--- a/internal/resources/yamls/app.go
+++ b/internal/resources/yamls/app.go
@@ -26,8 +26,6 @@ metadata:
     for-product: all
     bcdr-candidate: t
     component-name: iam-services
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
 data:
   realm: {{ .Realm }}
   client_id: {{ .ClientID }}
@@ -46,8 +44,6 @@ metadata:
     for-product: all
     bcdr-candidate: t
     component-name: iam-services 
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
 data:
   user_validation_api_v2: {{ .UserValidationAPIV2 }}
 type: Opaque
@@ -63,8 +59,6 @@ metadata:
     for-product: all
     bcdr-candidate: t
     component-name: iam-services
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
 stringData:
   pg_jdbc_host: common-service-db-rw
   pg_jdbc_port: "5432"
@@ -91,8 +85,6 @@ metadata:
     for-product: all
     bcdr-candidate: t
     component-name: iam-services
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
 data:
   DEFAULT_AUD_VALUE: {{ .DefaultAUDValue }}
   DEFAULT_REALM_VALUE: {{ .DefaultRealmValue }}
@@ -112,8 +104,6 @@ metadata:
     for-product: all
     bcdr-candidate: t
     component-name: iam-services
-  annotations:
-    argocd.argoproj.io/sync-wave: "3"
 spec:
   podSelector:
     matchLabels:
@@ -137,8 +127,6 @@ metadata:
     component-name: iam-services
     by-squad: mcsp-user-management
     for-product: all
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
 spec:
   podSelector:
     matchLabels:
@@ -181,8 +169,6 @@ metadata:
     for-product: all
     bcdr-candidate: t
     component-name: iam-services
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
 data:
   CLOUD_INSTANCE_ID: dev
   CLOUD_REGION: dev
@@ -201,7 +187,6 @@ metadata:
     bcdr-candidate: t
     component-name: iam-services
   annotations:
-    argocd.argoproj.io/sync-wave: "2"
     test: mcspid
 spec:
   backoffLimit: 3
@@ -254,6 +239,4 @@ metadata:
   labels:
     by-squad: mcsp-user-management
     for-product: all
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
 `

--- a/internal/resources/yamls/ui.go
+++ b/internal/resources/yamls/ui.go
@@ -23,8 +23,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name:  account-iam-ui-selfsigned-issuer
-  annotations:
-    argocd.argoproj.io/sync-wave: "00"
 spec:
   selfSigned: {}
 `
@@ -34,8 +32,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: account-iam-ui-selfsigned-ca-cert
-  annotations:
-    argocd.argoproj.io/sync-wave: "00"
 spec:
   isCA: true
   commonName: account-iam-ui-selfsigned-ca-cert
@@ -53,8 +49,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: account-iam-ui-product-reg-ca-issuer
-  annotations:
-    argocd.argoproj.io/sync-wave: "00"
 spec:
   ca:
     secretName: account-iam-ui-root-ca-cert
@@ -65,8 +59,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: account-iam-ui-server-cert
-  annotations:
-    argocd.argoproj.io/sync-wave: "00"
 spec:
   secretName: account-iam-ui-server-cert
   dnsNames:
@@ -90,7 +82,6 @@ metadata:
     app: 'account-iam-ui-api-service-onprem'
   name: 'account-iam-ui-api-service-onprem'
   annotations:
-    argocd.argoproj.io/sync-wave: '6'
     service.beta.openshift.io/serving-cert-secret-name: 'account-iam-ui-api-server-onprem-tls'
 spec:
   ports:
@@ -114,7 +105,6 @@ metadata:
     app: 'account-iam-ui-instance-service-onprem'
   name: 'account-iam-ui-instance-service-onprem'
   annotations:
-    argocd.argoproj.io/sync-wave: '6'
     service.beta.openshift.io/serving-cert-secret-name: 'account-iam-ui-instance-server-onprem-tls'
 spec:
   ports:
@@ -204,7 +194,6 @@ kind: Route
 metadata:
   name: 'account-iam-ui-instance-onprem'
   annotations:
-    argocd.argoproj.io/sync-wave: '8'
     haproxy.router.openshift.io/timeout: 30m
 spec:
   host: {{ .InstanceManagementHostname }}
@@ -227,7 +216,6 @@ kind: Route
 metadata:
   name: 'account-iam-ui-api-instance-onprem'
   annotations:
-    argocd.argoproj.io/sync-wave: '8'
     haproxy.router.openshift.io/timeout: 30m
 spec:
   host: {{ .InstanceManagementHostname }}
@@ -251,8 +239,6 @@ metadata:
   name: 'account-iam-ui-api-deployment-onprem'
   labels:
     app: account-iam-ui-api-service-onprem
-  annotations:
-    argocd.argoproj.io/sync-wave: '7'
 spec:
   selector:
     matchLabels:
@@ -421,8 +407,6 @@ metadata:
   name: 'account-iam-ui-instance-deployment-onprem'
   labels:
     app: account-iam-ui-instance-service-onprem
-  annotations:
-    argocd.argoproj.io/sync-wave: '7'
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64451

- This update introduces resource hash comparison and an annotation-based skip logic to the reconciliation process, allowing the operator to avoid unnecessary updates by comparing configuration hashes and skip-update annotation.
- Remove all the argocd annotation from the yaml templates