### PR TITLE
Add service account permission to user mgmt role

### DIFF
--- a/internal/resources/yamls/operand_rbac.go
+++ b/internal/resources/yamls/operand_rbac.go
@@ -12,19 +12,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: user-mgmt-operand-role
 rules:
-  - verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - delete
-    apiGroups:
-      - ''
-    resources:
-      - secrets
-      - configmaps
-      - pods
+  - apiGroups: [""]
+    resources: ["pods", "configmaps", "secrets", "serviceaccounts"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
 `
 
 const USER_MGMT_OPERAND_SA = `


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64778

Add permissions for the service account to the `user-mgmt-operand-role` Role, so the `mcsp-im-config-job` can update the IAM service account `ibm-iam-operand-restricted`