### PR TITLE
[MCSP] hash comparison and deep merge all the resources

### DIFF
--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -201,6 +201,7 @@ func (r *AccountIAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	klog.Infof("Reconcile completed successfully for AccountIAM CR %s/%s", instance.Namespace, instance.Name)
 	return ctrl.Result{}, nil
 }
 
@@ -855,22 +856,24 @@ func (r *AccountIAMReconciler) initUIBootstrapData(ctx context.Context, instance
 
 func (r *AccountIAMReconciler) createOrUpdate(ctx context.Context, obj *unstructured.Unstructured) error {
 
-	// only reachable if update DID see error IsNotFound
-	err := r.Create(ctx, obj)
-	if err != nil {
-		if !k8serrors.IsAlreadyExists(err) {
-			return err
-		}
-	}
-
-	// if the obj is Job, skip the update
-	if obj.GetKind() == "Job" {
-		return nil
-	}
-
 	fromCluster := &unstructured.Unstructured{}
 	fromCluster.SetGroupVersionKind(obj.GroupVersionKind())
-	if err := r.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, fromCluster); err != nil {
+	err := r.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, fromCluster)
+
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			_, templateHash, err := utils.CalculateHashes(nil, obj)
+			if err != nil {
+				return err
+			}
+			utils.SetHashAnnotation(obj, templateHash)
+
+			if err := r.Create(ctx, obj); err != nil {
+				return err
+			}
+			klog.V(2).Infof("Created resource %s %s/%s.", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+			return nil
+		}
 		return err
 	}
 
@@ -879,29 +882,47 @@ func (r *AccountIAMReconciler) createOrUpdate(ctx context.Context, obj *unstruct
 		return nil
 	}
 
-	rawData, err := yaml.Marshal(obj.Object)
+	// Get the hash of the existing and new resources
+	clusterHash, templateHash, err := utils.CalculateHashes(fromCluster, obj)
 	if err != nil {
 		return err
 	}
 
-	newHashedData := utils.HashResource(rawData)
-
-	// Check if the current hash matches the existing hash in the annotations
-	existingAnno := fromCluster.GetAnnotations()
-	if existingAnno != nil {
-		if existingAnno[resources.HashedData] == newHashedData {
-			klog.Infof("Resource %s %s/%s has not changed, skipping update.", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+	if obj.GetKind() == "Job" {
+		if templateHash == clusterHash {
+			klog.V(2).Infof("Job resource %s %s/%s has not changed, skipping update.", obj.GetKind(), obj.GetNamespace(), obj.GetName())
 			return nil
 		}
+
+		if err := r.Delete(ctx, fromCluster); err != nil {
+			return err
+		}
+
+		utils.SetHashAnnotation(obj, templateHash)
+
+		if err := r.Create(ctx, obj); err != nil {
+			return err
+		}
+		klog.Infof("Recreated Job resource %s %s/%s due to hash mismatch.", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+		return nil
 	}
 
-	// Set the new hash in the annotations
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
+	// handle non-Job resources
+	if clusterHash == templateHash {
+		// Merge fromTemplate into fromCluster and update
+		mergedObj := utils.MergeCR(fromCluster, obj)
+		utils.SetHashAnnotation(mergedObj, templateHash)
+		mergedObj.SetResourceVersion(fromCluster.GetResourceVersion())
+
+		if err := r.Update(ctx, mergedObj); err != nil {
+			return err
+		}
+		klog.V(2).Infof("Updated resource %s %s/%s with merged fields.", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+		return nil
 	}
-	annotations[resources.HashedData] = newHashedData
-	obj.SetAnnotations(annotations)
+
+	// If hashes don't match, overwrite fromCluster with fromTemplate
+	utils.SetHashAnnotation(obj, templateHash)
 
 	// Update the resource if the configuration has changed
 	obj.SetResourceVersion(fromCluster.GetResourceVersion())

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -35,6 +36,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -218,14 +220,7 @@ func InsertColonInURL(redisURL string) string {
 
 // CalculateHashes calculates the hash for the existing cluster resource and the new template resource
 func CalculateHashes(fromCluster *unstructured.Unstructured, fromTemplate *unstructured.Unstructured) (string, string, error) {
-	// Get the hash from annotations in the cluster resource
-	clusterAnnos := fromCluster.GetAnnotations()
-	clusterHash := ""
-	if clusterAnnos != nil {
-		clusterHash = clusterAnnos[resources.HashedData]
-	}
 
-	// Calculate the hash for the template resource
 	templateData, err := yaml.Marshal(fromTemplate.Object)
 	if err != nil {
 		return "", "", err
@@ -233,7 +228,15 @@ func CalculateHashes(fromCluster *unstructured.Unstructured, fromTemplate *unstr
 	templateHash := sha256.Sum256(templateData)
 	templateHashStr := hex.EncodeToString(templateHash[:7])
 
-	return clusterHash, templateHashStr, nil
+	if fromCluster != nil {
+		clusterAnnos := fromCluster.GetAnnotations()
+		clusterHash := ""
+		if clusterAnnos != nil {
+			clusterHash = clusterAnnos[resources.HashedData]
+		}
+		return clusterHash, templateHashStr, nil
+	}
+	return "", templateHashStr, nil
 }
 
 // SetHashAnnotation sets the hash annotation in the object
@@ -246,38 +249,132 @@ func SetHashAnnotation(obj *unstructured.Unstructured, hash string) {
 	obj.SetAnnotations(annotations)
 }
 
-func MergeCR(fromCluster *unstructured.Unstructured, fromTemplate *unstructured.Unstructured) *unstructured.Unstructured {
-	// Copy fromCluster so we don't modify the original
-	mergedObj := fromCluster.DeepCopy()
-
-	// Merge annotations
-	clusterAnnotations := mergedObj.GetAnnotations()
-	templateAnnotations := fromTemplate.GetAnnotations()
-
-	if clusterAnnotations == nil {
-		clusterAnnotations = make(map[string]string)
+// MergeResources merges two complete unstructured Kubernetes resources
+func MergeResources(fromCluster, fromTemplate *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	// Marshal both unstructured resources into []byte (JSON format)
+	fromClusterBytes, err := json.Marshal(fromCluster.Object)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal fromCluster resource: %v", err)
 	}
-	for key, value := range templateAnnotations {
-		clusterAnnotations[key] = value
+
+	fromTemplateBytes, err := json.Marshal(fromTemplate.Object)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal fromTemplate resource: %v", err)
 	}
-	mergedObj.SetAnnotations(clusterAnnotations)
 
-	// Merge labels
-	clusterLabels := mergedObj.GetLabels()
-	templateLabels := fromTemplate.GetLabels()
+	// Merge the resources
+	mergedResource := MergeCR(fromClusterBytes, fromTemplateBytes)
 
-	if clusterLabels == nil {
-		clusterLabels = make(map[string]string)
+	// Convert mergedResource back to unstructured.Unstructured object
+	mergedUnstructured := &unstructured.Unstructured{
+		Object: mergedResource,
 	}
-	for key, value := range templateLabels {
-		clusterLabels[key] = value
+
+	return mergedUnstructured, nil
+}
+
+// MergeCR deep merges two custom resource specs, along with labels and annotations.
+func MergeCR(defaultCR, changedCR []byte) map[string]interface{} {
+	if len(defaultCR) == 0 && len(changedCR) == 0 {
+		return make(map[string]interface{})
 	}
-	mergedObj.SetLabels(clusterLabels)
 
-	// Optionally, merge other fields if necessary (metadata, spec, etc.)
-	// In case other fields like `spec` need to be merged, it can be done here
+	defaultCRDecoded := make(map[string]interface{})
+	changedCRDecoded := make(map[string]interface{})
 
-	return mergedObj
+	// Handle when only one CR is provided
+	if len(defaultCR) != 0 && len(changedCR) == 0 {
+		if err := json.Unmarshal(defaultCR, &defaultCRDecoded); err != nil {
+			klog.Errorf("failed to unmarshal Template CR: %v", err)
+		}
+		return defaultCRDecoded
+	} else if len(defaultCR) == 0 && len(changedCR) != 0 {
+		if err := json.Unmarshal(changedCR, &changedCRDecoded); err != nil {
+			klog.Errorf("failed to unmarshal existing CR: %v", err)
+		}
+		return changedCRDecoded
+	}
+
+	if err := json.Unmarshal(defaultCR, &defaultCRDecoded); err != nil {
+		klog.Errorf("failed to unmarshal Template CR: %v", err)
+	}
+	if err := json.Unmarshal(changedCR, &changedCRDecoded); err != nil {
+		klog.Errorf("failed to unmarshal existing CR: %v", err)
+	}
+
+	// Merge both specs
+	for key := range defaultCRDecoded {
+		checkKeyBeforeMerging(key, defaultCRDecoded[key], changedCRDecoded[key], changedCRDecoded)
+	}
+
+	// Ensure labels and annotations are merged as well
+	mergeMetadata(defaultCRDecoded, changedCRDecoded)
+
+	return changedCRDecoded
+}
+
+// Helper function to merge metadata like labels and annotations
+func mergeMetadata(defaultCRDecoded, changedCRDecoded map[string]interface{}) {
+	// Handle metadata section
+	if defaultMeta, ok := defaultCRDecoded["metadata"].(map[string]interface{}); ok {
+		if changedMeta, ok := changedCRDecoded["metadata"].(map[string]interface{}); ok {
+			// Merge labels
+			if defaultLabels, ok := defaultMeta["labels"].(map[string]interface{}); ok {
+				if changedLabels, ok := changedMeta["labels"].(map[string]interface{}); ok {
+					for key, value := range defaultLabels {
+						changedLabels[key] = value
+					}
+				} else {
+					changedMeta["labels"] = defaultLabels
+				}
+			}
+			if defaultAnnotations, ok := defaultMeta["annotations"].(map[string]interface{}); ok {
+				if changedAnnotations, ok := changedMeta["annotations"].(map[string]interface{}); ok {
+					for key, value := range defaultAnnotations {
+						changedAnnotations[key] = value
+					}
+				} else {
+					changedMeta["annotations"] = defaultAnnotations
+				}
+			}
+		} else {
+			changedCRDecoded["metadata"] = defaultMeta
+		}
+	}
+}
+
+// Recursive function to merge spec
+func checkKeyBeforeMerging(key string, defaultMap, changedMap interface{}, finalMap map[string]interface{}) {
+	if !equality.Semantic.DeepEqual(defaultMap, changedMap) {
+		switch defaultVal := defaultMap.(type) {
+		case map[string]interface{}:
+			if changedMap == nil {
+				finalMap[key] = defaultVal
+			} else if changedVal, ok := changedMap.(map[string]interface{}); ok {
+				for newKey := range defaultVal {
+					checkKeyBeforeMerging(newKey, defaultVal[newKey], changedVal[newKey], finalMap[key].(map[string]interface{}))
+				}
+			}
+		case []interface{}:
+			if changedMap == nil {
+				finalMap[key] = defaultVal
+			} else if changedVal, ok := changedMap.([]interface{}); ok {
+				for i := range defaultVal {
+					if _, ok := defaultVal[i].(map[string]interface{}); ok {
+						if len(changedVal) > i {
+							for newKey := range defaultVal[i].(map[string]interface{}) {
+								checkKeyBeforeMerging(newKey, defaultVal[i].(map[string]interface{})[newKey], changedVal[i].(map[string]interface{})[newKey], finalMap[key].([]interface{})[i].(map[string]interface{}))
+							}
+						}
+					}
+				}
+			}
+		default:
+			if changedMap == nil {
+				finalMap[key] = defaultVal
+			}
+		}
+	}
 }
 
 // -------------- Wait Functions --------------

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/IBM/ibm-user-management-operator/internal/resources"
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
+	"github.com/ghodss/yaml"
 	ocproute "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -169,12 +170,6 @@ func GetSecretData(ctx context.Context, k8sClient client.Client, secretName, ns,
 	return string(data), nil
 }
 
-// HashResource generates a hash from the raw resource data
-func HashResource(rawData []byte) string {
-	hashedData := sha256.Sum256(rawData)
-	return hex.EncodeToString(hashedData[:7])
-}
-
 func CombineData(dataStructs ...interface{}) map[string]interface{} {
 	combinedData := make(map[string]interface{})
 
@@ -219,6 +214,70 @@ func InsertColonInURL(redisURL string) string {
 		return parts[0] + "@" + parts[1]
 	}
 	return redisURL
+}
+
+// CalculateHashes calculates the hash for the existing cluster resource and the new template resource
+func CalculateHashes(fromCluster *unstructured.Unstructured, fromTemplate *unstructured.Unstructured) (string, string, error) {
+	// Get the hash from annotations in the cluster resource
+	clusterAnnos := fromCluster.GetAnnotations()
+	clusterHash := ""
+	if clusterAnnos != nil {
+		clusterHash = clusterAnnos[resources.HashedData]
+	}
+
+	// Calculate the hash for the template resource
+	templateData, err := yaml.Marshal(fromTemplate.Object)
+	if err != nil {
+		return "", "", err
+	}
+	templateHash := sha256.Sum256(templateData)
+	templateHashStr := hex.EncodeToString(templateHash[:7])
+
+	return clusterHash, templateHashStr, nil
+}
+
+// SetHashAnnotation sets the hash annotation in the object
+func SetHashAnnotation(obj *unstructured.Unstructured, hash string) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[resources.HashedData] = hash
+	obj.SetAnnotations(annotations)
+}
+
+func MergeCR(fromCluster *unstructured.Unstructured, fromTemplate *unstructured.Unstructured) *unstructured.Unstructured {
+	// Copy fromCluster so we don't modify the original
+	mergedObj := fromCluster.DeepCopy()
+
+	// Merge annotations
+	clusterAnnotations := mergedObj.GetAnnotations()
+	templateAnnotations := fromTemplate.GetAnnotations()
+
+	if clusterAnnotations == nil {
+		clusterAnnotations = make(map[string]string)
+	}
+	for key, value := range templateAnnotations {
+		clusterAnnotations[key] = value
+	}
+	mergedObj.SetAnnotations(clusterAnnotations)
+
+	// Merge labels
+	clusterLabels := mergedObj.GetLabels()
+	templateLabels := fromTemplate.GetLabels()
+
+	if clusterLabels == nil {
+		clusterLabels = make(map[string]string)
+	}
+	for key, value := range templateLabels {
+		clusterLabels[key] = value
+	}
+	mergedObj.SetLabels(clusterLabels)
+
+	// Optionally, merge other fields if necessary (metadata, spec, etc.)
+	// In case other fields like `spec` need to be merged, it can be done here
+
+	return mergedObj
 }
 
 // -------------- Wait Functions --------------


### PR DESCRIPTION
Fix for a bunch of secrets issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64217
Enhancement ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64451

- Introduced a hash-based comparison to determine whether updates are needed. 
- For Jobs, if changes are detected, the resource is deleted and recreated. 
- For non-Job resources, the template is merged with the existing resource if the hashes match, ensuring new fields are added without overwriting unchanged ones. If the hashes don't match, the resource is overwritten by the template. 
- Implemented a solution for deep merging resources, including metadata and spec, by using the `mergeResources` function. 