### PR TITLE
Update certificate chain for user-mgmt operator and services

### DIFF
--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -23,6 +23,8 @@ const (
 	UserMgmtOpreq = "ibm-user-management-request"
 	// OpreqKind is the kind of OperandConfig
 	OpreqKind = "OperandRequest"
+	// CSCASecret is the name of the secret for CA certificate
+	CSCASecret = "cs-ca-certificate-secret"
 	// RedisOperator is the subscription name of Redis Operator
 	RedisOperator = "ibm-redis-cp-operator"
 	// Rediscp is the name of Redis CR
@@ -35,10 +37,6 @@ const (
 	RedisVersion = "v1"
 	//RedisURLssl
 	RedisURLssl = "redis-url-ssl"
-	// RedisURL is the Certificate of Redis
-	RedisCert = "account-iam-ui-redis-cert"
-	// RedisCertKey is the key of Redis CA Certificate
-	RedisCertKey = "cacertb64.pem"
 	// OpreqPhaseRunning is the Running status of Operand
 	OpreqPhaseRunning = "Running"
 	// OperandStatusReady is the Ready status of Operand
@@ -55,8 +53,6 @@ const (
 	CreateDBJob = "create-account-iam-db"
 	// DBMigrationJob is the name of the database migration job
 	DBMigrationJob = "account-iam-db-migration-mcspid"
-	// AccountIAM service secret
-	AccountIAMsvc = "account-iam-svc-tls-cm"
 	// IMConfigJob is the name of the IM configuration job
 	IMConfigJob = "mcsp-im-config-job"
 	// IMOIDCCrendential is the secret where the IM OIDC credential is stored

--- a/internal/resources/yamls/account_iam.go
+++ b/internal/resources/yamls/account_iam.go
@@ -2,9 +2,8 @@ package yamls
 
 var ACCOUNT_IAM_RES = []string{
 	ACCOUNT_IAM_CA_ISSUER,
-	ACCOUNT_IAM_SS_ISSUER,
 	ACCOUNT_IAM_CA_CERT,
-	ACCOUNT_IAM_SS_CERT,
+	ACCOUNT_IAM_SVC_CERT,
 	ACCOUNT_IAM_SERVICE_ACCOUNT,
 	ACCOUNT_IAM_SERVICE,
 	ACCOUNT_IAM_DEPLOYMENT,
@@ -18,49 +17,45 @@ var ACCOUNT_IAM_CA_ISSUER = `
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: wlo-ca-issuer
+  name: account-iam-ca-issuer
 spec:
   ca:
-    secretName: wlo-ca-tls
-`
-
-var ACCOUNT_IAM_SS_ISSUER = `
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: wlo-self-signed
-spec:
-  selfSigned: {}
+    secretName: cs-ca-certificate
 `
 
 var ACCOUNT_IAM_CA_CERT = `
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: account-iam-svc-tls-cm
+  name: account-iam-ca-cert
+spec:
+  isCA: true
+  commonName: account-iam-ca-cert
+  secretName: account-iam-ca-cert
+  duration: 8766h0m0s
+  issuerRef:
+    name: account-iam-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+`
+
+var ACCOUNT_IAM_SVC_CERT = `
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: account-iam-svc-tls-cert
 spec:
   commonName: account-iam.mcsp1.svc
+  secretName: account-iam-svc-tls-cert
   dnsNames:
     - account-iam.mcsp1.svc
     - account-iam.mcsp1.svc.cluster.local
   duration: 2160h0m0s
   issuerRef:
-    name: wlo-ca-issuer
-  secretName: account-iam-svc-tls-cm
-`
-
-var ACCOUNT_IAM_SS_CERT = `
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: wlo-ca-cert
-spec:
-  commonName: User Management Operator
-  duration: 8766h0m0s
-  isCA: true
-  issuerRef:
-    name: wlo-self-signed
-  secretName: wlo-ca-tls
+    name: account-iam-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+  
 `
 
 var ACCOUNT_IAM_SERVICE_ACCOUNT = `
@@ -279,7 +274,7 @@ spec:
               name: account-iam-mpconfig-secrets
       - name: svc-certificate
         secret:
-          secretName: account-iam-svc-tls-cm
+          secretName: account-iam-svc-tls-cert
 `
 
 var ACCOUNT_IAM_ROUTE = `

--- a/internal/resources/yamls/account_iam.go
+++ b/internal/resources/yamls/account_iam.go
@@ -20,7 +20,7 @@ metadata:
   name: account-iam-ca-issuer
 spec:
   ca:
-    secretName: cs-ca-certificate
+    secretName: cs-ca-certificate-secret
 `
 
 var ACCOUNT_IAM_CA_CERT = `
@@ -55,7 +55,6 @@ spec:
     name: account-iam-ca-issuer
     kind: Issuer
     group: cert-manager.io
-  
 `
 
 var ACCOUNT_IAM_SERVICE_ACCOUNT = `

--- a/internal/resources/yamls/create_redis.go
+++ b/internal/resources/yamls/create_redis.go
@@ -1,6 +1,12 @@
 package yamls
 
-const RedisCRTemplate = `
+var REDIS_CERTS = []string{
+	REDIS_CA_ISSUER,
+	REDIS_CA_CERT,
+	REDIS_SVC_CERT,
+}
+
+var RedisCRTemplate = `
 apiVersion: redis.ibm.com/v1
 kind: Rediscp
 metadata:
@@ -9,8 +15,49 @@ spec:
   size: {{.RedisCRSize}}
   license:
      accept: true
-  cert_name: account-iam-ui-redis-cert
+  cert_name: account-iam-ui-redis-svc-tls-cert
   shutdown: false
   scale_config: medium
   version: {{.RedisCRVersion}}
+`
+
+var REDIS_CA_ISSUER = `
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: account-iam-ui-redis-ca-issuer
+spec:
+  ca:
+    secretName: cs-ca-certificate
+`
+
+var REDIS_CA_CERT = `
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: account-iam-ui-redis-ca-cert
+spec:
+  isCA: true
+  commonName: account-iam-ui-redis-ca-cert
+  secretName: account-iam-ui-redis-ca-cert
+  duration: 87660h0m0s
+  renewBefore: 85500h0m0s
+  issuerRef:
+    name: account-iam-ui-redis-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
+`
+
+var REDIS_SVC_CERT = `
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: account-iam-ui-redis-svc-tls-cert
+spec:
+  commonName: account-iam-ui-redis-svc-tls-cert
+  secretName: account-iam-ui-redis-svc-tls-cert
+  issuerRef:
+    name: account-iam-ui-redis-ca-issuer
+    kind: Issuer
+    group: cert-manager.io
 `

--- a/internal/resources/yamls/create_redis.go
+++ b/internal/resources/yamls/create_redis.go
@@ -28,7 +28,7 @@ metadata:
   name: account-iam-ui-redis-ca-issuer
 spec:
   ca:
-    secretName: cs-ca-certificate
+    secretName: cs-ca-certificate-secret
 `
 
 var REDIS_CA_CERT = `

--- a/internal/resources/yamls/ui.go
+++ b/internal/resources/yamls/ui.go
@@ -24,7 +24,7 @@ metadata:
   name: account-iam-ui-ca-issuer
 spec:
   ca:
-    secretName: cs-ca-certificate
+    secretName: cs-ca-certificate-secret
 `
 
 var UI_CA_CERT = `
@@ -511,5 +511,4 @@ spec:
               - key: 'service-ca.crt'
                 path: ca.crt
       serviceAccountName: user-mgmt-operand-serviceaccount
-
 `

--- a/internal/resources/yamls/ui.go
+++ b/internal/resources/yamls/ui.go
@@ -1,9 +1,8 @@
 package yamls
 
 var StaticYamlsUI = []string{
-	IssuerSS,
-	CertCA,
-	IssuerCA,
+	UI_ISSUER_CA,
+	UI_CA_CERT,
 	SvcAPI,
 	SvcInstance,
 	DeploymentAPI,
@@ -11,60 +10,51 @@ var StaticYamlsUI = []string{
 }
 
 var TemplateYamlsUI = []string{
-	CertUI,
+	UI_SVC_CERT,
 	ConfigUI,
 	SecretUI,
 	RouteInstance,
 	RouteAPIInstance,
 }
 
-var IssuerSS = `
+var UI_ISSUER_CA = `
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name:  account-iam-ui-selfsigned-issuer
+  name: account-iam-ui-ca-issuer
 spec:
-  selfSigned: {}
+  ca:
+    secretName: cs-ca-certificate
 `
 
-var CertCA = `
+var UI_CA_CERT = `
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: account-iam-ui-selfsigned-ca-cert
+  name: account-iam-ui-ca-cert
 spec:
   isCA: true
-  commonName: account-iam-ui-selfsigned-ca-cert
-  secretName: account-iam-ui-root-ca-cert
+  commonName: account-iam-ui-ca-cert
+  secretName: account-iam-ui-ca-cert
   duration: 87660h0m0s
   renewBefore: 85500h0m0s
   issuerRef:
-    name: account-iam-ui-selfsigned-issuer
+    name: account-iam-ui-ca-issuer
     kind: Issuer
     group: cert-manager.io
 `
 
-var IssuerCA = `
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: account-iam-ui-product-reg-ca-issuer
-spec:
-  ca:
-    secretName: account-iam-ui-root-ca-cert
-`
-
-var CertUI = `
+var UI_SVC_CERT = `
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: account-iam-ui-server-cert
+  name: account-iam-ui-svc-tls-cert
 spec:
-  secretName: account-iam-ui-server-cert
+  secretName: account-iam-ui-svc-tls-cert
   dnsNames:
     - {{ .Hostname }}
   issuerRef:
-    name: account-iam-ui-product-reg-ca-issuer
+    name: account-iam-ui-ca-issuer
     kind: Issuer
     group: cert-manager.io
 `
@@ -389,7 +379,7 @@ spec:
           projected:
             sources:
               - secret:
-                  name:  'account-iam-ui-server-cert'
+                  name:  'account-iam-ui-svc-tls-cert'
                   items:
                     - key: ca.crt
                       path: ca.crt


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64767

This update consolidates the certificate management for the `user-managment` operator and its dependencies by replacing multiple self-signed certificates with a certificate chain.

