### PR TITLE
Creating IM job by using the values from integration secret

### DIFF
--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -55,6 +55,8 @@ const (
 	EDBClusterKind = "Cluster"
 	// EDBAPIGroupVersion is the api group version of Cluster
 	EDBAPIGroupVersion = "postgresql.k8s.enterprisedb.io/v1"
+	// BootstrapSecret is the name of the secret for user management bootstrap
+	BootstrapSecret = "user-mgmt-bootstrap"
 	// CreateDBJob is the name of the database creation job
 	CreateDBJob = "create-account-iam-db"
 	// DBMigrationJob is the name of the database migration job

--- a/internal/resources/yamls/app.go
+++ b/internal/resources/yamls/app.go
@@ -72,6 +72,8 @@ data:
   pgPassword: {{ .PGPassword }}
   GLOBAL_ACCOUNT_AUD: {{ .GlobalAccountAud }}
   GLOBAL_ACCOUNT_REALM: {{ .GlobalRealmValue }}
+  ENCRYPTION_KEYS: {{ .EncryptionKeys }}
+  CURRENT_ENCRYPTION_KEY_NUM: {{ .CurrentEncryptionKeyNum }}
 type: Opaque
 `
 

--- a/internal/resources/yamls/im_config.go
+++ b/internal/resources/yamls/im_config.go
@@ -72,6 +72,6 @@ spec:
               secretKeyRef:
                 name: mcsp-im-integration-details
                 key: SERVICEID_NAME
-      serviceAccountName: mcsp-im-config-job
+      serviceAccountName: user-mgmt-operand-serviceaccount
       restartPolicy: OnFailure
 `

--- a/internal/resources/yamls/im_config.go
+++ b/internal/resources/yamls/im_config.go
@@ -31,16 +31,47 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         env:
-          - name: LOG_LEVEL
-            value: debug
           - name: NAMESPACE
-            value: {{ .AccountIAMNamespace }}
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: IM_HOST_BASE_URL
-            value: {{ .IMURL }}
+            valueFrom:
+              configMapKeyRef:
+                name: ibm-iam-bindinfo-ibmcloud-cluster-info
+                key: cluster_endpoint
           - name: ACCOUNT_IAM_BASE_URL
-            value: {{ .AccountIAMURL }}
+            valueFrom:
+              secretKeyRef:
+                name: mcsp-im-integration-details
+                key: ACCOUNT_IAM_URL
           - name: ACCOUNT_IAM_CONSOLE_BASE_URL
-            value: {{ .AccountIAMConsoleURL }}
-      serviceAccountName: user-mgmt-operand-serviceaccount
+            valueFrom:
+              secretKeyRef:
+                name: mcsp-im-integration-details
+                key: ACCOUNT_IAM_CONSOLE_URL
+          - name: API_KEY_SECRET_NAME
+            value: mcsp-im-integration-details
+          - name: ACCOUNT_NAME
+            valueFrom:
+              secretKeyRef:
+                name: mcsp-im-integration-details
+                key: ACCOUNT_NAME
+          - name: SUBSCRIPTION_NAME
+            valueFrom:
+              secretKeyRef:
+                name: mcsp-im-integration-details
+                key: SUBSCRIPTION_NAME
+          - name: SERVICE_NAME
+            valueFrom:
+              secretKeyRef:
+                name: mcsp-im-integration-details
+                key: SERVICE_NAME
+          - name: SERVICEID_NAME
+            valueFrom:
+              secretKeyRef:
+                name: mcsp-im-integration-details
+                key: SERVICEID_NAME
+      serviceAccountName: mcsp-im-config-job
       restartPolicy: OnFailure
 `

--- a/internal/resources/yamls/im_integration.go
+++ b/internal/resources/yamls/im_integration.go
@@ -1,0 +1,20 @@
+package yamls
+
+var IM_INTEGRATION_YAMLS = []string{
+	IM_INTEGRATION_SECRET,
+}
+
+var IM_INTEGRATION_SECRET = `
+kind: Secret
+apiVersion: v1
+metadata:
+  name: mcsp-im-integration-details
+stringData:
+  ACCOUNT_IAM_CONSOLE_URL: {{ .AccountIAMConsoleURL }}
+  ACCOUNT_IAM_URL: {{ .AccountIAMURL }}
+  ACCOUNT_NAME: {{ .AccountName }}
+  SERVICEID_NAME: {{ .ServiceIDName }}
+  SERVICE_NAME: {{ .ServiceName }}
+  SUBSCRIPTION_NAME: {{ .SubscriptionName }}
+type: Opaque
+`


### PR DESCRIPTION
Ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64687

1. The `user-mgmt-operator` will create a new secret named `mcsp-im-integration-details` to store all IM integration values.
2. Apply the job `mcsp-im-config-job` using all the references from the above secret.
3. Generate encryption key for account IAM and save it in `account-iam-database-secret` secret

### Test
- Test image: quay.io/yuchen_shen/ibm-user-management-operator:integration_secret
- Update IM job image in CSV with: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/mcsp-im-config-job-amd64:c47ff7e
