### PR TITLE
Add namespace dynamic injection to certificate template

### DIFF
--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -589,6 +589,7 @@ func (r *AccountIAMReconciler) reconcileOperandResources(ctx context.Context, in
 	klog.Infof("Creating Account IAM yamls")
 	for _, v := range res.ACCOUNT_IAM_RES {
 		object := &unstructured.Unstructured{}
+		v = strings.ReplaceAll(v, "${NAMESPACE}", instance.Namespace)
 		v = utils.ReplaceImages(v)
 		manifest := []byte(v)
 		if err := yaml.Unmarshal(manifest, object); err != nil {

--- a/internal/resources/yamls/account_iam.go
+++ b/internal/resources/yamls/account_iam.go
@@ -45,11 +45,11 @@ kind: Certificate
 metadata:
   name: account-iam-svc-tls-cert
 spec:
-  commonName: account-iam.mcsp1.svc
+  commonName: account-iam.${NAMESPACE}.svc
   secretName: account-iam-svc-tls-cert
   dnsNames:
-    - account-iam.mcsp1.svc
-    - account-iam.mcsp1.svc.cluster.local
+    - account-iam.${NAMESPACE}.svc
+    - account-iam.${NAMESPACE}.svc.cluster.local
   duration: 2160h0m0s
   issuerRef:
     name: account-iam-ca-issuer


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65135

With this fix, the `commonName` and `dnsNames` in `account-iam-svc-tls-cert` certificate will reflect the actual namespace dynamically, making the certificate configuration specific to the AccountIAM instance’s namespace.

Test passed and image: quay.io/yuchen_shen/ibm-user-management-operator:cert_ns

