### PR TITLE
update account iam env development configmap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/gomega v1.33.1
 	github.com/openshift/api v0.0.0-20240618130602-c6bd48c5ea89
 	github.com/operator-framework/api v0.25.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.30.2
 	k8s.io/apimachinery v0.30.2
 	k8s.io/client-go v0.30.2
@@ -67,7 +68,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.30.2 // indirect
 	k8s.io/klog v1.0.0 // indirect

--- a/internal/resources/yamls/account_iam.go
+++ b/internal/resources/yamls/account_iam.go
@@ -173,7 +173,7 @@ spec:
           value: "230832362"
         envFrom:
         - configMapRef:
-            name: account-iam-env-configmap-dev
+            name: account-iam-env-configmap-development
         ports:
         - containerPort: 9445
           name: 9445-tcp

--- a/internal/resources/yamls/app.go
+++ b/internal/resources/yamls/app.go
@@ -165,7 +165,7 @@ const CONFIG_ENV = `
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: account-iam-env-configmap-dev
+  name: account-iam-env-configmap-development
   labels:
     by-squad: mcsp-user-management
     for-product: all
@@ -176,6 +176,7 @@ data:
   CLOUD_REGION: dev
   NOTIFICATION_SERVICE_ENABLED: ""
   LOCAL_TOKEN_ISSUER: https://127.0.0.1:9443/oidc/endpoint/OP
+  TOKEN_EXCHANGE_VALIDATE_ROLES: "true"
 `
 
 const DB_MIGRATION_MCSPID = `


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65280

Add `TOKEN_EXCHANGE_VALIDATE_ROLES` value into the `account-iam-env-configmap-development` configmap and set it as `true` as default

test image: quay.io/yuchen_shen/ibm-user-management-operator:dev