### PR TITLE
fix flag to allow account iam application to start with new image

### DIFF
--- a/internal/resources/yamls/app.go
+++ b/internal/resources/yamls/app.go
@@ -43,7 +43,7 @@ metadata:
     by-squad: mcsp-user-management
     for-product: all
     bcdr-candidate: t
-    component-name: iam-services 
+    component-name: iam-services
 data:
   user_validation_api_v2: {{ .UserValidationAPIV2 }}
 type: Opaque
@@ -109,12 +109,12 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      name: account-iam 
+      name: account-iam
   ingress:
     - ports:
         # calls to the API
         - protocol: TCP
-          port: 9445 
+          port: 9445
   policyTypes:
     - Ingress
 `
@@ -132,7 +132,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      name: account-iam 
+      name: account-iam
   policyTypes:
     - Egress
   egress:
@@ -174,7 +174,7 @@ metadata:
 data:
   CLOUD_INSTANCE_ID: dev
   CLOUD_REGION: dev
-  NOTIFICATION_SERVICE_ENABLED: ""
+  NOTIFICATION_SERVICE_ENABLED: "false"
   LOCAL_TOKEN_ISSUER: https://127.0.0.1:9443/oidc/endpoint/OP
   TOKEN_EXCHANGE_VALIDATE_ROLES: "true"
 `


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66240
account iam application was not starting with the latest account-iam image because the notification flag in the account-iam-env-configmap-development configmap needed a value and could no longer be empty string.  Setting to false.