### PR TITLE
fix: correct pgPassword key in db_bootstrap job

### DIFF
--- a/internal/resources/yamls/db_bootstrap.go
+++ b/internal/resources/yamls/db_bootstrap.go
@@ -37,7 +37,7 @@ spec:
         secret:
           secretName: user-mgmt-bootstrap
           items:
-          - key: PGPassword
+          - key: pgPassword
             path: password
           defaultMode: 420  
       - name: data-volume


### PR DESCRIPTION
According to [json format](https://github.com/IBM/ibm-user-management-operator/blob/d58bbfdd82862b5b1c8735eafdaf33c9d067c1be/internal/controller/accountiam_controller.go#L69), the secret `user-mgmt-bootstrap` has field `pgPassword`, updating the reference in job `create-account-iam-db`.