### PR TITLE
Update Redis CR version to 1.2.8

### DIFF
--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -385,7 +385,7 @@ func (r *AccountIAMReconciler) createRedisCR(ctx context.Context, instance *oper
 	klog.Infof("Redis CRD exists, creating Redis CR %s in namespace %s", resources.Rediscp, instance.Namespace)
 	redisCRData := RedisCRParams{
 		RedisCRSize:    3,
-		RedisCRVersion: "1.2.0",
+		RedisCRVersion: "1.2.8",
 	}
 
 	if err := r.injectData(ctx, instance, []string{res.RedisCRTemplate}, redisCRData); err != nil {


### PR DESCRIPTION
Description: Redis CR version 1.2.0 is not supported by Redis 1.2.8 operator, update the version to the latest `1.2.8` to avoid the error:
```
fatal: [localhost]: FAILED! => {"changed": false, "reason": "the role 'rediscp_1.2.0' was not found in /opt/ansible/roles:/opt/ansible/roles:/opt/ansible"}
```
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66170