### PR TITLE
[UM] Add AccountIAM controller test suits

### DIFF
--- a/internal/controller/accountiam_controller_test.go
+++ b/internal/controller/accountiam_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1alpha1 "github.com/IBM/ibm-user-management-operator/api/v1alpha1"
+	"github.com/IBM/ibm-user-management-operator/internal/controller/testutils"
 )
 
 var _ = Describe("AccountIAM Controller", func() {
@@ -175,7 +176,7 @@ var _ = Describe("AccountIAM Controller", func() {
 					NamespacedName: namespacedName,
 				})
 
-				// What we're actually testing here:
+				// What actually testing here:
 				// 1. Controller maintains state consistency
 				// 2. Error handling doesn't leak resources
 				// 3. Reconcile loop behaves predictably
@@ -380,21 +381,21 @@ var _ = Describe("AccountIAM Controller", func() {
 	Context("When testing utility functions", func() {
 		It("should properly check if string is in slice", func() {
 			slice := []string{"pass", "fail", "notFound"}
-			Expect(contains(slice, "fail")).To(BeTrue())
-			Expect(contains(slice, "orange")).To(BeFalse())
+			Expect(testutils.Contains(slice, "fail")).To(BeTrue())
+			Expect(testutils.Contains(slice, "failed")).To(BeFalse())
 		})
 
 		It("should properly remove string from slice", func() {
 			slice := []string{"pass", "fail", "notFound"}
-			result := remove(slice, "fail")
+			result := testutils.Remove(slice, "fail")
 			Expect(result).To(Equal([]string{"pass", "notFound"}))
 			Expect(len(result)).To(Equal(2))
 		})
 
 		It("should handle empty slices", func() {
 			var emptySlice []string
-			Expect(contains(emptySlice, "test")).To(BeFalse())
-			result := remove(emptySlice, "test")
+			Expect(testutils.Contains(emptySlice, "test")).To(BeFalse())
+			result := testutils.Remove(emptySlice, "test")
 			Expect(result).To(BeEmpty())
 		})
 	})
@@ -723,23 +724,3 @@ var _ = Describe("AccountIAM Controller", func() {
 		})
 	})
 })
-
-// Helper functions for testing
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
-}
-
-func remove(slice []string, item string) []string {
-	var result []string
-	for _, s := range slice {
-		if s != item {
-			result = append(result, s)
-		}
-	}
-	return result
-}

--- a/internal/controller/accountiam_controller_test.go
+++ b/internal/controller/accountiam_controller_test.go
@@ -18,67 +18,221 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1alpha1 "github.com/IBM/ibm-user-management-operator/api/v1alpha1"
 )
 
 var _ = Describe("AccountIAM Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+	const (
+		AccountIAMName      = "test-accountiam"
+		AccountIAMNamespace = "ibm-common-services"
+		timeout             = time.Second * 30
+		interval            = time.Millisecond * 250
+	)
 
-		ctx := context.Background()
+	var (
+		ctx = context.Background()
+	)
 
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		accountiam := &operatorv1alpha1.AccountIAM{}
+	Context("When reconciling an AccountIAM resource", func() {
+		var (
+			accountIAM *operatorv1alpha1.AccountIAM
+			reconciler *AccountIAMReconciler
+			recorder   *record.FakeRecorder
+		)
 
 		BeforeEach(func() {
-			By("creating the custom resource for the Kind AccountIAM")
-			err := k8sClient.Get(ctx, typeNamespacedName, accountiam)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &operatorv1alpha1.AccountIAM{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: AccountIAMNamespace,
+				},
+			}
+			err := k8sClient.Create(ctx, namespace)
+			if err != nil && !errors.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// Create AccountIAM resource
+			accountIAM = &operatorv1alpha1.AccountIAM{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      AccountIAMName,
+					Namespace: AccountIAMNamespace,
+				},
+				Spec: operatorv1alpha1.AccountIAMSpec{},
+			}
+
+			// Create the AccountIAM resource
+			Expect(k8sClient.Create(ctx, accountIAM)).Should(Succeed())
+
+			// Set up reconciler
+			recorder = record.NewFakeRecorder(100)
+			reconciler = &AccountIAMReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: recorder,
 			}
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &operatorv1alpha1.AccountIAM{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance AccountIAM")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &AccountIAMReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+			// Clean up the AccountIAM resource
+			err := k8sClient.Delete(ctx, accountIAM)
+			if err != nil && !errors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred())
 			}
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      AccountIAMName,
+					Namespace: AccountIAMNamespace,
+				}, accountIAM)
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			namespacedName := types.NamespacedName{
+				Name:      AccountIAMName,
+				Namespace: AccountIAMNamespace,
+			}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			// The reconciler should handle the resource without error
+			Expect(result).NotTo(BeNil())
+		})
+
+		It("should handle missing AccountIAM resource gracefully", func() {
+			By("Reconciling a non-existent resource")
+			namespacedName := types.NamespacedName{
+				Name:      "non-existent",
+				Namespace: AccountIAMNamespace,
+			}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+
+		It("should handle finalizer logic correctly", func() {
+			By("Checking finalizer handling during reconciliation")
+			namespacedName := types.NamespacedName{
+				Name:      AccountIAMName,
+				Namespace: AccountIAMNamespace,
+			}
+
+			// Reconcile to potentially add finalizer
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// Check current state of resource
+			updatedAccountIAM := &operatorv1alpha1.AccountIAM{}
+			err = k8sClient.Get(ctx, namespacedName, updatedAccountIAM)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the resource exists
+			Expect(updatedAccountIAM.Name).To(Equal(AccountIAMName))
+		})
+
+		It("should handle deletion gracefully", func() {
+			By("Testing deletion workflow")
+			namespacedName := types.NamespacedName{
+				Name:      AccountIAMName,
+				Namespace: AccountIAMNamespace,
+			}
+
+			// First reconcile to set up the resource
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Delete the resource
+			err = k8sClient.Delete(ctx, accountIAM)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reconcile after deletion to test cleanup logic
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should validate basic AccountIAM structure", func() {
+			By("Checking that the AccountIAM resource is properly structured")
+			Expect(accountIAM.Name).To(Equal(AccountIAMName))
+			Expect(accountIAM.Namespace).To(Equal(AccountIAMNamespace))
+			Expect(accountIAM.Kind).To(Equal(""))       // Kind is usually empty in tests
+			Expect(accountIAM.APIVersion).To(Equal("")) // APIVersion is usually empty in tests
+		})
+
+		It("should handle status updates correctly", func() {
+			By("Reconciling and checking status updates")
+			namespacedName := types.NamespacedName{
+				Name:      AccountIAMName,
+				Namespace: AccountIAMNamespace,
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: namespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Get the updated resource and verify it's still accessible
+			updatedAccountIAM := &operatorv1alpha1.AccountIAM{}
+			err = k8sClient.Get(ctx, namespacedName, updatedAccountIAM)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the resource was processed correctly
+			Expect(updatedAccountIAM.Name).To(Equal(AccountIAMName))
+			Expect(updatedAccountIAM.Namespace).To(Equal(AccountIAMNamespace))
+		})
+
+		It("should handle reconciler setup correctly", func() {
+			By("Verifying reconciler is properly configured")
+			Expect(reconciler.Client).NotTo(BeNil())
+			Expect(reconciler.Scheme).NotTo(BeNil())
+			Expect(reconciler.Recorder).NotTo(BeNil())
 		})
 	})
+
 })
+
+// Helper functions for testing (these would be in utils.go normally)
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func remove(slice []string, item string) []string {
+	var result []string
+	for _, s := range slice {
+		if s != item {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"fmt"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,6 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	operatorv1alpha1 "github.com/IBM/ibm-user-management-operator/api/v1alpha1"
+	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -53,11 +53,7 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false, // Set to false for testing without all CRDs
-
-		// Optional: Set BinaryAssetsDirectory if you have kubebuilder binaries
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		ErrorIfCRDPathMissing: false,
 	}
 
 	var err error
@@ -73,6 +69,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = rbacv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = odlm.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = routev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/internal/controller/testutils/slice_utils.go
+++ b/internal/controller/testutils/slice_utils.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+// Contains checks if a string is present in a slice of strings.
+// Returns true if the item is found, false otherwise.
+func Contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// Remove removes all occurrences of a string from a slice of strings.
+// Returns a new slice with the item removed.
+func Remove(slice []string, item string) []string {
+	var result []string
+	for _, s := range slice {
+		if s != item {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/internal/controller/testutils/slice_utils_test.go
+++ b/internal/controller/testutils/slice_utils_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"testing"
+)
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []string
+		item     string
+		expected bool
+	}{
+		{"item exists", []string{"a", "b", "c"}, "b", true},
+		{"item not exists", []string{"a", "b", "c"}, "d", false},
+		{"empty slice", []string{}, "a", false},
+		{"nil slice", nil, "a", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Contains(tt.slice, tt.item)
+			if result != tt.expected {
+				t.Errorf("Contains(%v, %q) = %v, want %v", tt.slice, tt.item, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []string
+		item     string
+		expected []string
+	}{
+		{"remove existing item", []string{"a", "b", "c"}, "b", []string{"a", "c"}},
+		{"remove non-existing item", []string{"a", "b", "c"}, "d", []string{"a", "b", "c"}},
+		{"remove from empty slice", []string{}, "a", []string{}},
+		{"remove multiple occurrences", []string{"a", "b", "b", "c"}, "b", []string{"a", "c"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Remove(tt.slice, tt.item)
+			if len(result) != len(tt.expected) {
+				t.Errorf("Remove(%v, %q) length = %d, want %d", tt.slice, tt.item, len(result), len(tt.expected))
+				return
+			}
+			for i, v := range result {
+				if i >= len(tt.expected) || v != tt.expected[i] {
+					t.Errorf("Remove(%v, %q) = %v, want %v", tt.slice, tt.item, result, tt.expected)
+					break
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Description
Adds a full test suite for the AccountIAM controller, covering all parts of the reconciliation process and related infrastructure

#### Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64742

#### What's added
1. Complete Test Infrastructure `suite_test.go`
  
    - Kube Test Env Sets up realistic test environment using envtest
    - Schema Registration: Registers all required API types (AccountIAM, ConfigMaps, Secrets, RBAC)
    - Environment Management: Handles setup/teardown of test Kubernetes API server

2. Comprehensive Controller Tests `accountiam_controller_test.go`
Implements 6-phase testing approach that mirrors the controller's reconciliation logic:

    - Phase 1: Resource Validation
    - Phase 2: Prerequisites Verification
    - Phase 3: Resource Management
    - Phase 4: Status Management
    - Phase 5: Error Scenarios

3. Utility Function Testing

    -  Tests `contains()` helper function for slice operations
    - Tests `remove()` helper function for slice manipulation
    - Validates edge cases with empty slices
  
Test image: `quay.io/yuchen_shen/ibm-user-management-operator:mcsp_test`