### PR TITLE
update IAM-UM configuration key and remove OSAUTH_ENABLED flag

### DIFF
--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -929,9 +929,8 @@ func (r *AccountIAMReconciler) configureAuthenticationViaCS(ctx context.Context,
 			"spec": map[string]interface{}{
 				"authentication": map[string]interface{}{
 					"config": map[string]interface{}{
-						"oidcIssuerURL":  integrationData.DefaultIDPValue,
-						"IAM-UM":         true,
-						"OSAUTH_ENABLED": false,
+						"oidcIssuerURL": integrationData.DefaultIDPValue,
+						"iamUm":         true,
 					},
 				},
 			},
@@ -971,17 +970,10 @@ func (r *AccountIAMReconciler) configureAuthenticationViaCS(ctx context.Context,
 			needsUpdate = true
 		}
 
-		// Check and update IAM-UM
-		if currentIAMUM, ok := config["IAM-UM"].(bool); !ok || !currentIAMUM {
-			klog.Infof("Setting IAM-UM to true")
-			config["IAM-UM"] = true
-			needsUpdate = true
-		}
-
-		// Check and update OSAUTH_ENABLED
-		if currentOSAuth, ok := config["OSAUTH_ENABLED"].(bool); !ok || currentOSAuth {
-			klog.Infof("Setting OSAUTH_ENABLED to false")
-			config["OSAUTH_ENABLED"] = false
+		// Check and update iamUm
+		if currentIAMUM, ok := config["iamUm"].(bool); !ok || !currentIAMUM {
+			klog.Infof("Setting iamUm to true")
+			config["iamUm"] = true
 			needsUpdate = true
 		}
 


### PR DESCRIPTION
This is per request from IAM team about their changes in ibm-iam-operator under PR https://github.com/IBM/ibm-iam-operator/pull/1089 for ticket https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67439

It is to configure Authentication CR with `.spec.config.iamUm` and remove field `OSAUTH_ENABLED`.

### How to test
1. patch user mgmt operator CSV with following image 
```console
➜  ~ oc get csv ibm-user-management-operator.v1.0.0 -ojsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].image}'
quay.io/daniel_fan/ibm-user-management-operator:dev%
```
2. Verify the CommonService CR is patched by user mgmt operator for corresponding fields
```console
➜  ~ oc get commonservice common-service -o jsonpath='{.spec.services[?(@.name=="ibm-im-operator")].spec}' | jq
{
  "authentication": {
    "config": {
      "iamUm": true,
      "oidcIssuerURL": "https://cp-console-user-mgmt.apps.installer-cp3pt0.cp.fyre.ibm.com/idprovider/v1/auth"
    }
  }
}
```
2. Verify the Authentication CR is updated properly with the field
```console
➜  ~ oc get authentication.operator.ibm.com example-authentication -o jsonpath='{.spec.config.iamUm}'
true%
➜  ~ oc get authentication.operator.ibm.com example-authentication -o jsonpath='{.spec.config.oidcIssuerURL}'
https://cp-console-user-mgmt.apps.installer-cp3pt0.cp.fyre.ibm.com/idprovider/v1/auth%                                                                                         ➜  ~
```