### PR TITLE
Add Phase Status Support to AccountIAM Operator

### DIFF
--- a/api/v1alpha1/accountiam_types.go
+++ b/api/v1alpha1/accountiam_types.go
@@ -21,6 +21,28 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// AccountIAM Phase constants (CR lifecycle phases)
+const (
+	PhaseInitializing = "Initializing"
+	PhaseCreating     = "Creating"
+	PhasePending      = "Pending"
+	PhaseRunning      = "Running"
+	PhaseReady        = "Ready"
+	PhaseFailed       = "Failed"
+	PhaseError        = "Error"
+)
+
+// Resource Status constants (individual resource states)
+const (
+	StatusReady     = "Ready"
+	StatusNotReady  = "NotReady"
+	StatusPending   = "Pending"
+	StatusCompleted = "Completed"
+	StatusFailed    = "Failed"
+	StatusError     = "Error"
+	StatusNotFound  = "NotFound"
+)
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 

--- a/api/v1alpha1/accountiam_types.go
+++ b/api/v1alpha1/accountiam_types.go
@@ -54,6 +54,9 @@ type AccountIAMSpec struct {
 
 // AccountIAMStatus defines the observed state of AccountIAM
 type AccountIAMStatus struct {
+	// Phase represents the current phase of the AccountIAM lifecycle
+	// +kubebuilder:validation:Enum=Initializing;Creating;Pending;Running;Ready;Failed;Error
+	Phase string `json:"phase,omitempty"`
 
 	// Import the operandstatus from odlm
 	Service odlm.OperandStatus `json:"service,omitempty"`

--- a/bundle/manifests/operator.ibm.com_accountiams.yaml
+++ b/bundle/manifests/operator.ibm.com_accountiams.yaml
@@ -47,6 +47,18 @@ spec:
           status:
             description: AccountIAMStatus defines the observed state of AccountIAM
             properties:
+              phase:
+                description: Phase represents the current phase of the AccountIAM
+                  lifecycle
+                enum:
+                - Initializing
+                - Creating
+                - Pending
+                - Running
+                - Ready
+                - Failed
+                - Error
+                type: string
               service:
                 description: Import the operandstatus from odlm
                 properties:

--- a/config/crd/bases/operator.ibm.com_accountiams.yaml
+++ b/config/crd/bases/operator.ibm.com_accountiams.yaml
@@ -47,6 +47,18 @@ spec:
           status:
             description: AccountIAMStatus defines the observed state of AccountIAM
             properties:
+              phase:
+                description: Phase represents the current phase of the AccountIAM
+                  lifecycle
+                enum:
+                - Initializing
+                - Creating
+                - Pending
+                - Running
+                - Ready
+                - Failed
+                - Error
+                type: string
               service:
                 description: Import the operandstatus from odlm
                 properties:

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -204,7 +204,7 @@ func (r *AccountIAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Initialize phase if not set
 	if instance.Status.Phase == "" {
-		instance.Status.Phase = resources.PhaseInitializing
+		instance.Status.Phase = operatorv1alpha1.PhaseInitializing
 		klog.Infof("Setting initial phase to %s for AccountIAM %s/%s", instance.Status.Phase, instance.Namespace, instance.Name)
 	}
 
@@ -221,15 +221,15 @@ func (r *AccountIAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	reconcileCtx := &ReconcileContext{Instance: instance}
 
 	// Set phase to creating when starting reconciliation
-	if instance.Status.Phase == resources.PhaseInitializing {
-		instance.Status.Phase = resources.PhaseCreating
+	if instance.Status.Phase == operatorv1alpha1.PhaseInitializing {
+		instance.Status.Phase = operatorv1alpha1.PhaseCreating
 		klog.Infof("Updating phase to %s for AccountIAM %s/%s", instance.Status.Phase, instance.Namespace, instance.Name)
 	}
 
 	// Execute reconciliation phases
 	if err := r.reconcilePhases(ctx, reconcileCtx); err != nil {
 		// Set phase to failed on error
-		instance.Status.Phase = resources.PhaseFailed
+		instance.Status.Phase = operatorv1alpha1.PhaseFailed
 		klog.Errorf("Reconciliation failed for AccountIAM %s/%s, setting phase to %s: %v", instance.Namespace, instance.Name, instance.Status.Phase, err)
 		return ctrl.Result{}, err
 	}
@@ -245,11 +245,11 @@ func (r *AccountIAMReconciler) reconcilePhases(ctx context.Context, reconcileCtx
 		function func(context.Context, *ReconcileContext) error
 		phase    string
 	}{
-		{"initializeReconcileContext", r.initializeReconcileContext, resources.PhaseCreating},
-		{"reconcilePrerequisites", r.reconcilePrerequisites, resources.PhasePending},
-		{"reconcileOperandResources", r.reconcileOperandResourcesPhase, resources.PhaseRunning},
-		{"reconcileIMConfiguration", r.reconcileIMConfiguration, resources.PhaseRunning},
-		{"reconcileUI", r.reconcileUIPhase, resources.PhaseRunning},
+		{"initializeReconcileContext", r.initializeReconcileContext, operatorv1alpha1.PhaseCreating},
+		{"reconcilePrerequisites", r.reconcilePrerequisites, operatorv1alpha1.PhasePending},
+		{"reconcileOperandResources", r.reconcileOperandResourcesPhase, operatorv1alpha1.PhaseRunning},
+		{"reconcileIMConfiguration", r.reconcileIMConfiguration, operatorv1alpha1.PhaseRunning},
+		{"reconcileUI", r.reconcileUIPhase, operatorv1alpha1.PhaseRunning},
 	}
 
 	for _, phase := range phases {
@@ -496,7 +496,7 @@ func (r *AccountIAMReconciler) createRedisCR(ctx context.Context, reconcileCtx *
 	}
 
 	// Wait for Redis CR to be ready
-	return utils.WaitForRediscp(ctx, r.Client, instance.Namespace, resources.Rediscp, resources.RedisAPIGroup, resources.RedisKind, resources.Version, resources.StatusCompleted)
+	return utils.WaitForRediscp(ctx, r.Client, instance.Namespace, resources.Rediscp, resources.RedisAPIGroup, resources.RedisKind, resources.Version, operatorv1alpha1.StatusCompleted)
 }
 
 // InitBootstrapData initializes BootstrapData with default values
@@ -1318,7 +1318,7 @@ func (r *AccountIAMReconciler) updateManagedResourcesStatus(ctx context.Context,
 		Kind:       resources.UserMgmtCR,
 		APIVersion: resources.OperatorIBMApiVersion,
 		Namespace:  instance.Namespace,
-		Status:     resources.PhaseRunning, // Default to running, will update based on resource status
+		Status:     operatorv1alpha1.PhaseRunning, // Default to running, will update based on resource status
 	}
 
 	var managedResources []odlm.ResourceStatus
@@ -1398,16 +1398,16 @@ func (r *AccountIAMReconciler) updateManagedResourcesStatus(ctx context.Context,
 
 	// Update service status based on resource readiness
 	if allResourcesReady {
-		accountIAMService.Status = resources.StatusReady
+		accountIAMService.Status = operatorv1alpha1.StatusReady
 	} else {
 		// Check current phase to determine appropriate status
 		switch instance.Status.Phase {
-		case resources.PhaseInitializing, resources.PhaseCreating:
-			accountIAMService.Status = resources.StatusPending
-		case resources.PhaseFailed, resources.PhaseError:
-			accountIAMService.Status = resources.StatusError
+		case operatorv1alpha1.PhaseInitializing, operatorv1alpha1.PhaseCreating:
+			accountIAMService.Status = operatorv1alpha1.StatusPending
+		case operatorv1alpha1.PhaseFailed, operatorv1alpha1.PhaseError:
+			accountIAMService.Status = operatorv1alpha1.StatusError
 		default:
-			accountIAMService.Status = resources.StatusNotReady
+			accountIAMService.Status = operatorv1alpha1.StatusNotReady
 		}
 	}
 
@@ -1423,7 +1423,7 @@ func (r *AccountIAMReconciler) updateManagedResourcesStatus(ctx context.Context,
 // updatePhaseBasedOnResources updates the phase field based on the current state of managed resources
 func (r *AccountIAMReconciler) updatePhaseBasedOnResources(instance *operatorv1alpha1.AccountIAM) {
 	// If already in failed state, don't change it
-	if instance.Status.Phase == resources.PhaseFailed || instance.Status.Phase == resources.PhaseError {
+	if instance.Status.Phase == operatorv1alpha1.PhaseFailed || instance.Status.Phase == operatorv1alpha1.PhaseError {
 		return
 	}
 
@@ -1431,31 +1431,31 @@ func (r *AccountIAMReconciler) updatePhaseBasedOnResources(instance *operatorv1a
 	serviceStatus := instance.Status.Service.Status
 
 	switch serviceStatus {
-	case resources.StatusReady, resources.PhaseRunning:
+	case operatorv1alpha1.StatusReady, operatorv1alpha1.PhaseRunning:
 		// All resources are ready and operational
-		if instance.Status.Phase != resources.PhaseReady {
-			instance.Status.Phase = resources.PhaseReady
+		if instance.Status.Phase != operatorv1alpha1.PhaseReady {
+			instance.Status.Phase = operatorv1alpha1.PhaseReady
 			klog.Infof("Setting phase to %s for AccountIAM %s/%s - all resources are ready",
 				instance.Status.Phase, instance.Namespace, instance.Name)
 		}
-	case resources.StatusNotReady, resources.StatusPending:
+	case operatorv1alpha1.StatusNotReady, operatorv1alpha1.StatusPending:
 		// Some resources are not ready yet, but reconciliation is progressing
-		if instance.Status.Phase != resources.PhasePending && instance.Status.Phase != resources.PhaseCreating {
-			instance.Status.Phase = resources.PhasePending
+		if instance.Status.Phase != operatorv1alpha1.PhasePending && instance.Status.Phase != operatorv1alpha1.PhaseCreating {
+			instance.Status.Phase = operatorv1alpha1.PhasePending
 			klog.Infof("Setting phase to %s for AccountIAM %s/%s - waiting for resources to be ready",
 				instance.Status.Phase, instance.Namespace, instance.Name)
 		}
-	case resources.StatusNotFound, resources.StatusError:
+	case operatorv1alpha1.StatusNotFound, operatorv1alpha1.StatusError:
 		// Some resources have errors
-		if instance.Status.Phase != resources.PhaseError {
-			instance.Status.Phase = resources.PhaseError
+		if instance.Status.Phase != operatorv1alpha1.PhaseError {
+			instance.Status.Phase = operatorv1alpha1.PhaseError
 			klog.Infof("Setting phase to %s for AccountIAM %s/%s - some resources have errors",
 				instance.Status.Phase, instance.Namespace, instance.Name)
 		}
 	default:
 		// For any other status, keep the current phase or set to running if creating
-		if instance.Status.Phase == resources.PhaseCreating {
-			instance.Status.Phase = resources.PhaseRunning
+		if instance.Status.Phase == operatorv1alpha1.PhaseCreating {
+			instance.Status.Phase = operatorv1alpha1.PhaseRunning
 			klog.Infof("Setting phase to %s for AccountIAM %s/%s - reconciliation in progress",
 				instance.Status.Phase, instance.Namespace, instance.Name)
 		}

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -1420,6 +1420,48 @@ func (r *AccountIAMReconciler) updateManagedResourcesStatus(ctx context.Context,
 
 }
 
+// updatePhaseBasedOnResources updates the phase field based on the current state of managed resources
+func (r *AccountIAMReconciler) updatePhaseBasedOnResources(instance *operatorv1alpha1.AccountIAM) {
+	// If already in failed state, don't change it
+	if instance.Status.Phase == resources.PhaseFailed || instance.Status.Phase == resources.PhaseError {
+		return
+	}
+
+	// Check the overall service status to determine phase
+	serviceStatus := instance.Status.Service.Status
+
+	switch serviceStatus {
+	case resources.StatusReady, resources.PhaseRunning:
+		// All resources are ready and operational
+		if instance.Status.Phase != resources.PhaseReady {
+			instance.Status.Phase = resources.PhaseReady
+			klog.Infof("Setting phase to %s for AccountIAM %s/%s - all resources are ready",
+				instance.Status.Phase, instance.Namespace, instance.Name)
+		}
+	case resources.StatusNotReady, resources.StatusPending:
+		// Some resources are not ready yet, but reconciliation is progressing
+		if instance.Status.Phase != resources.PhasePending && instance.Status.Phase != resources.PhaseCreating {
+			instance.Status.Phase = resources.PhasePending
+			klog.Infof("Setting phase to %s for AccountIAM %s/%s - waiting for resources to be ready",
+				instance.Status.Phase, instance.Namespace, instance.Name)
+		}
+	case resources.StatusNotFound, resources.StatusError:
+		// Some resources have errors
+		if instance.Status.Phase != resources.PhaseError {
+			instance.Status.Phase = resources.PhaseError
+			klog.Infof("Setting phase to %s for AccountIAM %s/%s - some resources have errors",
+				instance.Status.Phase, instance.Namespace, instance.Name)
+		}
+	default:
+		// For any other status, keep the current phase or set to running if creating
+		if instance.Status.Phase == resources.PhaseCreating {
+			instance.Status.Phase = resources.PhaseRunning
+			klog.Infof("Setting phase to %s for AccountIAM %s/%s - reconciliation in progress",
+				instance.Status.Phase, instance.Namespace, instance.Name)
+		}
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccountIAMReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -211,6 +211,7 @@ func (r *AccountIAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Defer status update for managed resources and phase
 	defer func() {
 		r.updateManagedResourcesStatus(ctx, instance)
+		r.updatePhaseBasedOnResources(instance)
 		if !reflect.DeepEqual(originalStatus, instance.Status) {
 			r.updateStatus(ctx, instance)
 		}
@@ -1392,6 +1393,21 @@ func (r *AccountIAMReconciler) updateManagedResourcesStatus(ctx context.Context,
 		managedResources = append(managedResources, routeResource)
 		if !routeReady {
 			allResourcesReady = false
+		}
+	}
+
+	// Update service status based on resource readiness
+	if allResourcesReady {
+		accountIAMService.Status = resources.StatusReady
+	} else {
+		// Check current phase to determine appropriate status
+		switch instance.Status.Phase {
+		case resources.PhaseInitializing, resources.PhaseCreating:
+			accountIAMService.Status = resources.StatusPending
+		case resources.PhaseFailed, resources.PhaseError:
+			accountIAMService.Status = resources.StatusError
+		default:
+			accountIAMService.Status = resources.StatusNotReady
 		}
 	}
 

--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -202,7 +202,13 @@ func (r *AccountIAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Create a copy of the status to detect changes
 	originalStatus := instance.Status.DeepCopy()
 
-	// Defer status update for managed resources
+	// Initialize phase if not set
+	if instance.Status.Phase == "" {
+		instance.Status.Phase = resources.PhaseInitializing
+		klog.Infof("Setting initial phase to %s for AccountIAM %s/%s", instance.Status.Phase, instance.Namespace, instance.Name)
+	}
+
+	// Defer status update for managed resources and phase
 	defer func() {
 		r.updateManagedResourcesStatus(ctx, instance)
 		if !reflect.DeepEqual(originalStatus, instance.Status) {
@@ -213,8 +219,17 @@ func (r *AccountIAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Create reconcile context
 	reconcileCtx := &ReconcileContext{Instance: instance}
 
+	// Set phase to creating when starting reconciliation
+	if instance.Status.Phase == resources.PhaseInitializing {
+		instance.Status.Phase = resources.PhaseCreating
+		klog.Infof("Updating phase to %s for AccountIAM %s/%s", instance.Status.Phase, instance.Namespace, instance.Name)
+	}
+
 	// Execute reconciliation phases
 	if err := r.reconcilePhases(ctx, reconcileCtx); err != nil {
+		// Set phase to failed on error
+		instance.Status.Phase = resources.PhaseFailed
+		klog.Errorf("Reconciliation failed for AccountIAM %s/%s, setting phase to %s: %v", instance.Namespace, instance.Name, instance.Status.Phase, err)
 		return ctrl.Result{}, err
 	}
 
@@ -224,16 +239,28 @@ func (r *AccountIAMReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 // reconcilePhases executes all reconciliation phases in order
 func (r *AccountIAMReconciler) reconcilePhases(ctx context.Context, reconcileCtx *ReconcileContext) error {
-	phases := []func(context.Context, *ReconcileContext) error{
-		r.initializeReconcileContext,
-		r.reconcilePrerequisites,
-		r.reconcileOperandResourcesPhase,
-		r.reconcileIMConfiguration,
-		r.reconcileUIPhase,
+	phases := []struct {
+		name     string
+		function func(context.Context, *ReconcileContext) error
+		phase    string
+	}{
+		{"initializeReconcileContext", r.initializeReconcileContext, resources.PhaseCreating},
+		{"reconcilePrerequisites", r.reconcilePrerequisites, resources.PhasePending},
+		{"reconcileOperandResources", r.reconcileOperandResourcesPhase, resources.PhaseRunning},
+		{"reconcileIMConfiguration", r.reconcileIMConfiguration, resources.PhaseRunning},
+		{"reconcileUI", r.reconcileUIPhase, resources.PhaseRunning},
 	}
 
 	for _, phase := range phases {
-		if err := phase(ctx, reconcileCtx); err != nil {
+		// Update phase before executing each major phase
+		if reconcileCtx.Instance.Status.Phase != phase.phase {
+			reconcileCtx.Instance.Status.Phase = phase.phase
+			klog.Infof("Entering %s phase for AccountIAM %s/%s", phase.phase, reconcileCtx.Instance.Namespace, reconcileCtx.Instance.Name)
+		}
+
+		klog.Infof("Executing reconciliation phase: %s", phase.name)
+		if err := phase.function(ctx, reconcileCtx); err != nil {
+			klog.Errorf("Failed in %s phase: %v", phase.name, err)
 			return err
 		}
 	}
@@ -1290,7 +1317,7 @@ func (r *AccountIAMReconciler) updateManagedResourcesStatus(ctx context.Context,
 		Kind:       resources.UserMgmtCR,
 		APIVersion: resources.OperatorIBMApiVersion,
 		Namespace:  instance.Namespace,
-		Status:     resources.PhaseRunning, // Default to running, will update if any resource is not ready
+		Status:     resources.PhaseRunning, // Default to running, will update based on resource status
 	}
 
 	var managedResources []odlm.ResourceStatus
@@ -1366,10 +1393,6 @@ func (r *AccountIAMReconciler) updateManagedResourcesStatus(ctx context.Context,
 		if !routeReady {
 			allResourcesReady = false
 		}
-	}
-
-	if !allResourcesReady {
-		accountIAMService.Status = resources.StatusNotReady
 	}
 
 	accountIAMService.ManagedResources = managedResources

--- a/internal/controller/utils/utils_test.go
+++ b/internal/controller/utils/utils_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	operatorv1alpha1 "github.com/IBM/ibm-user-management-operator/api/v1alpha1"
 	"github.com/IBM/ibm-user-management-operator/internal/resources"
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -399,7 +400,7 @@ var _ = Describe("Resource Status Functions", func() {
 			status, ready := GetRedisResourceStatus(ctx, fakeClient, testNamespace)
 
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotFound))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotFound))
 			Expect(status.ObjectName).To(Equal(resources.Rediscp))
 			Expect(status.Kind).To(Equal(resources.RedisKind))
 		})
@@ -414,7 +415,7 @@ var _ = Describe("Resource Status Functions", func() {
 						"namespace": testNamespace,
 					},
 					"status": map[string]interface{}{
-						resources.RedisStatus: resources.StatusCompleted,
+						resources.RedisStatus: operatorv1alpha1.StatusCompleted,
 					},
 				},
 			}
@@ -428,7 +429,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetRedisResourceStatus(ctx, fakeClient, testNamespace)
 			Expect(ready).To(BeTrue())
-			Expect(status.Status).To(Equal(resources.StatusCompleted))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusCompleted))
 		})
 
 		It("should return not ready when Redis CR exists but not completed", func() {
@@ -455,7 +456,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetRedisResourceStatus(ctx, fakeClient, testNamespace)
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotReady))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotReady))
 		})
 
 		It("should handle Redis CR with partial status", func() {
@@ -482,7 +483,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetRedisResourceStatus(ctx, fakeClient, testNamespace)
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusError))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusError))
 		})
 
 		It("should handle Redis CR with empty status", func() {
@@ -506,7 +507,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetRedisResourceStatus(ctx, fakeClient, testNamespace)
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusError))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusError))
 		})
 	})
 
@@ -515,7 +516,7 @@ var _ = Describe("Resource Status Functions", func() {
 			status, ready := GetOperandRequestStatus(ctx, fakeClient, testNamespace)
 
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotFound))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotFound))
 			Expect(status.ObjectName).To(Equal(resources.UserMgmtOpreq))
 		})
 
@@ -526,7 +527,7 @@ var _ = Describe("Resource Status Functions", func() {
 					Namespace: testNamespace,
 				},
 				Status: odlm.OperandRequestStatus{
-					Phase: resources.PhaseRunning,
+					Phase: operatorv1alpha1.PhaseRunning,
 				},
 			}
 
@@ -534,7 +535,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetOperandRequestStatus(ctx, fakeClient, testNamespace)
 			Expect(ready).To(BeTrue())
-			Expect(status.Status).To(Equal(resources.PhaseRunning))
+			Expect(status.Status).To(Equal(operatorv1alpha1.PhaseRunning))
 		})
 
 		It("should handle OperandRequest with different phases", func() {
@@ -575,7 +576,7 @@ var _ = Describe("Resource Status Functions", func() {
 			status, ready := GetJobStatus(ctx, fakeClient, "test-job", testNamespace)
 
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotFound))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotFound))
 			Expect(status.ObjectName).To(Equal("test-job"))
 		})
 
@@ -599,7 +600,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetJobStatus(ctx, fakeClient, "test-job", testNamespace)
 			Expect(ready).To(BeTrue())
-			Expect(status.Status).To(Equal(resources.StatusCompleted))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusCompleted))
 		})
 
 		It("should return failed when Job has failed", func() {
@@ -622,7 +623,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetJobStatus(ctx, fakeClient, "test-job", testNamespace)
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusFailed))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusFailed))
 		})
 
 		It("should return running when Job is in progress", func() {
@@ -640,7 +641,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetJobStatus(ctx, fakeClient, "test-job", testNamespace)
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.PhaseRunning))
+			Expect(status.Status).To(Equal(operatorv1alpha1.PhaseRunning))
 		})
 	})
 
@@ -649,7 +650,7 @@ var _ = Describe("Resource Status Functions", func() {
 			status, ready := GetServiceStatus(ctx, fakeClient, "test-service", testNamespace)
 
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotFound))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotFound))
 		})
 
 		It("should return completed when Service has ClusterIP", func() {
@@ -668,7 +669,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetServiceStatus(ctx, fakeClient, "test-service", testNamespace)
 			Expect(ready).To(BeTrue())
-			Expect(status.Status).To(Equal(resources.StatusCompleted))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusCompleted))
 		})
 
 		It("should return completed for headless service", func() {
@@ -687,7 +688,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetServiceStatus(ctx, fakeClient, "test-service", testNamespace)
 			Expect(ready).To(BeTrue())
-			Expect(status.Status).To(Equal(resources.StatusCompleted))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusCompleted))
 		})
 
 		It("should return not ready when Service has no ClusterIP", func() {
@@ -706,7 +707,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetServiceStatus(ctx, fakeClient, "test-service", testNamespace)
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotReady))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotReady))
 		})
 	})
 
@@ -715,7 +716,7 @@ var _ = Describe("Resource Status Functions", func() {
 			status, ready := GetSecretStatus(ctx, fakeClient, "test-secret", testNamespace)
 
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotFound))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotFound))
 		})
 
 		It("should return completed when Secret exists", func() {
@@ -733,7 +734,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetSecretStatus(ctx, fakeClient, "test-secret", testNamespace)
 			Expect(ready).To(BeTrue())
-			Expect(status.Status).To(Equal(resources.StatusCompleted))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusCompleted))
 		})
 	})
 
@@ -742,7 +743,7 @@ var _ = Describe("Resource Status Functions", func() {
 			status, ready := GetRouteStatus(ctx, fakeClient, "test-route", testNamespace)
 
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotFound))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotFound))
 		})
 
 		It("should return completed when Route is admitted", func() {
@@ -769,7 +770,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetRouteStatus(ctx, fakeClient, "test-route", testNamespace)
 			Expect(ready).To(BeTrue())
-			Expect(status.Status).To(Equal(resources.StatusCompleted))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusCompleted))
 		})
 
 		It("should return not ready when Route has no ingress", func() {
@@ -787,7 +788,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetRouteStatus(ctx, fakeClient, "test-route", testNamespace)
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotReady))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotReady))
 		})
 
 		It("should return not ready when Route is not admitted", func() {
@@ -814,7 +815,7 @@ var _ = Describe("Resource Status Functions", func() {
 
 			status, ready := GetRouteStatus(ctx, fakeClient, "test-route", testNamespace)
 			Expect(ready).To(BeFalse())
-			Expect(status.Status).To(Equal(resources.StatusNotReady))
+			Expect(status.Status).To(Equal(operatorv1alpha1.StatusNotReady))
 		})
 	})
 })

--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -65,8 +65,21 @@ const (
 	RedisCACert = "account-iam-ui-redis-ca-cert"
 	// RedisCert is the name of Redis service Certificate and secret
 	RedisSVCCert = "account-iam-ui-redis-svc-tls-cert"
+	// Phase constants for AccountIAM lifecycle
+	// PhaseInitializing is the phase when the AccountIAM is being initialized
+	PhaseInitializing = "Initializing"
+	// PhaseCreating is the phase when resources are being created
+	PhaseCreating = "Creating"
 	// PhaseRunning is the Running status
 	PhaseRunning = "Running"
+	// PhaseReady is the phase when all resources are ready and operational
+	PhaseReady = "Ready"
+	// PhaseFailed is the phase when reconciliation has failed
+	PhaseFailed = "Failed"
+	// PhaseError is the phase when an error occurred during reconciliation
+	PhaseError = "Error"
+	// PhasePending is the phase when waiting for dependencies
+	PhasePending = "Pending"
 	// StatusCompleted is the Completed status
 	StatusCompleted = "Completed"
 	// StatusReady is the Ready status

--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -115,22 +115,4 @@ const (
 	SkipAnnotation = "operator.ibm.com/ibm-user-management-operator.skip-update"
 	//HashedData is the key for checking the checksum of data section
 	HashedData string = "operator.ibm.com/ibm-user-management-operator.hashedData"
-
-	// AccountIAM Phase constants (CR lifecycle phases)
-	PhaseInitializing = "Initializing"
-	PhaseCreating     = "Creating"
-	PhasePending      = "Pending"
-	PhaseRunning      = "Running"
-	PhaseReady        = "Ready"
-	PhaseFailed       = "Failed"
-	PhaseError        = "Error"
-
-	// Resource Status constants (individual resource states)
-	StatusReady     = "Ready"
-	StatusNotReady  = "NotReady"
-	StatusPending   = "Pending"
-	StatusCompleted = "Completed"
-	StatusFailed    = "Failed"
-	StatusError     = "Error"
-	StatusNotFound  = "NotFound"
 )

--- a/internal/resources/constant.go
+++ b/internal/resources/constant.go
@@ -65,35 +65,6 @@ const (
 	RedisCACert = "account-iam-ui-redis-ca-cert"
 	// RedisCert is the name of Redis service Certificate and secret
 	RedisSVCCert = "account-iam-ui-redis-svc-tls-cert"
-	// Phase constants for AccountIAM lifecycle
-	// PhaseInitializing is the phase when the AccountIAM is being initialized
-	PhaseInitializing = "Initializing"
-	// PhaseCreating is the phase when resources are being created
-	PhaseCreating = "Creating"
-	// PhaseRunning is the Running status
-	PhaseRunning = "Running"
-	// PhaseReady is the phase when all resources are ready and operational
-	PhaseReady = "Ready"
-	// PhaseFailed is the phase when reconciliation has failed
-	PhaseFailed = "Failed"
-	// PhaseError is the phase when an error occurred during reconciliation
-	PhaseError = "Error"
-	// PhasePending is the phase when waiting for dependencies
-	PhasePending = "Pending"
-	// StatusCompleted is the Completed status
-	StatusCompleted = "Completed"
-	// StatusReady is the Ready status
-	StatusReady = "Ready"
-	// StatusNotReady is the NotReady status
-	StatusNotReady = "NotReady"
-	// StatusNotFound is the NotFound status
-	StatusNotFound = "NotFound"
-	// StatusPending is the Pending status
-	StatusPending = "Pending"
-	// StatusFailed is the Failed status
-	StatusFailed = "Failed"
-	// StatusError is the Error status
-	StatusError = "Error"
 	// IMPackage is the name of IM Operator
 	IMPackage = "ibm-im-operator"
 	// EDBClusterKind is the kind of Cluster
@@ -144,4 +115,22 @@ const (
 	SkipAnnotation = "operator.ibm.com/ibm-user-management-operator.skip-update"
 	//HashedData is the key for checking the checksum of data section
 	HashedData string = "operator.ibm.com/ibm-user-management-operator.hashedData"
+
+	// AccountIAM Phase constants (CR lifecycle phases)
+	PhaseInitializing = "Initializing"
+	PhaseCreating     = "Creating"
+	PhasePending      = "Pending"
+	PhaseRunning      = "Running"
+	PhaseReady        = "Ready"
+	PhaseFailed       = "Failed"
+	PhaseError        = "Error"
+
+	// Resource Status constants (individual resource states)
+	StatusReady     = "Ready"
+	StatusNotReady  = "NotReady"
+	StatusPending   = "Pending"
+	StatusCompleted = "Completed"
+	StatusFailed    = "Failed"
+	StatusError     = "Error"
+	StatusNotFound  = "NotFound"
 )


### PR DESCRIPTION
#### Summary
Added phase lifecycle management to the AccountIAM CR to provide better visibility into the operator's reconciliation progress.

#### Task
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67373

#### Changes

- Added `status.phase` field to AccountIAM CRD with validation enum
- Supported phases: `Initializing`, `Creating`, `Pending`, `Running`, `Ready`, `Failed`, `Error`
- Implemented phase transitions during reconciliation lifecycle
- Added `updatePhaseBasedOnResources()` method for phase determination
- Enhanced status update logic to track both individual resource status and overall phase

#### How to test
1. Test image: quay.io/yuchen_shen/ibm-user-management-operator:phase
2. Install UM as usual
3. New `status.phase` is shown in the AccountIAM CR
    ```
    status:
      phase: Ready
      service:
      ...
    ```